### PR TITLE
fixing UAL and AArch64 by using archive.org

### DIFF
--- a/instruction_docs/aarch64.py
+++ b/instruction_docs/aarch64.py
@@ -2,6435 +2,6435 @@ instrs = {
     "ABS": [
         {
             "instr": "ABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440142.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440142.htm",
             "short": "Absolute value (vector)",
         },
         {
             "instr": "ABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897487464.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897487464.htm",
             "short": "Absolute value (vector)",
         },
     ],
     "ADC": [
         {
             "instr": "ADC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897641164.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897641164.htm",
             "short": "Add with Carry",
         }
     ],
     "ADCS": [
         {
             "instr": "ADCS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897641554.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897641554.htm",
             "short": "Add with Carry, setting flags",
         }
     ],
     "ADD": [
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897642464.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897642464.htm",
             "short": "Add (extended register)",
         },
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897643454.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897643454.htm",
             "short": "Add (immediate)",
         },
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897643854.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897643854.htm",
             "short": "Add (shifted register)",
         },
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440522.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440522.htm",
             "short": "Add (vector)",
         },
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897487984.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897487984.htm",
             "short": "Add (vector)",
         },
     ],
     "ADDHN": [
         {
             "instr": "ADDHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897488575.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897488575.htm",
             "short": "Add returning High Narrow",
         }
     ],
     "ADDHN2": [
         {
             "instr": "ADDHN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897488575.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897488575.htm",
             "short": "Add returning High Narrow",
         }
     ],
     "ADDP": [
         {
             "instr": "ADDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440902.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897440902.htm",
             "short": "Add Pair of elements (scalar)",
         },
         {
             "instr": "ADDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897489165.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897489165.htm",
             "short": "Add Pairwise (vector)",
         },
     ],
     "ADDS": [
         {
             "instr": "ADDS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897644304.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897644304.htm",
             "short": "Add (extended register), setting flags",
         },
         {
             "instr": "ADDS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897644784.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897644784.htm",
             "short": "Add (immediate), setting flags",
         },
         {
             "instr": "ADDS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897645224.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897645224.htm",
             "short": "Add (shifted register), setting flags",
         },
     ],
     "ADDV": [
         {
             "instr": "ADDV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897489675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897489675.htm",
             "short": "Add across Vector",
         }
     ],
     "ADR": [
         {
             "instr": "ADR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897645644.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897645644.htm",
             "short": "Form PC-relative address",
         }
     ],
     "ADRL": [
         {
             "instr": "ADRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139165628.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139165628.htm",
             "short": "Load a PC-relative address into a register",
         }
     ],
     "ADRP": [
         {
             "instr": "ADRP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897646444.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897646444.htm",
             "short": "Form PC-relative address to 4KB page",
         }
     ],
     "AND": [
         {
             "instr": "AND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897646844.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897646844.htm",
             "short": "Bitwise AND (immediate)",
         },
         {
             "instr": "AND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897647244.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897647244.htm",
             "short": "Bitwise AND (shifted register)",
         },
         {
             "instr": "AND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897490205.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897490205.htm",
             "short": "Bitwise AND (vector)",
         },
     ],
     "ANDS": [
         {
             "instr": "ANDS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897647674.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897647674.htm",
             "short": "Bitwise AND (immediate), setting flags",
         },
         {
             "instr": "ANDS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648094.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648094.htm",
             "short": "Bitwise AND (shifted register), setting flags",
         },
     ],
     "ASR": [
         {
             "instr": "ASR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648514.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648514.htm",
             "short": "Arithmetic Shift Right (register)",
         },
         {
             "instr": "ASR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648934.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897648934.htm",
             "short": "Arithmetic Shift Right (immediate)",
         },
     ],
     "ASRV": [
         {
             "instr": "ASRV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897649344.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897649344.htm",
             "short": "Arithmetic Shift Right Variable",
         }
     ],
     "AT": [
         {
             "instr": "AT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897649784.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897649784.htm",
             "short": "Address Translate",
         }
     ],
     "AUTDA": [
         {
             "instr": "AUTDA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ycn1476202675817.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ycn1476202675817.htm",
             "short": "Authenticate Data address, using key A",
         }
     ],
     "AUTDB": [
         {
             "instr": "AUTDB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_epx1476202676637.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_epx1476202676637.htm",
             "short": "Authenticate Data address, using key B",
         }
     ],
     "AUTDZA": [
         {
             "instr": "AUTDZA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ycn1476202675817.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ycn1476202675817.htm",
             "short": "Authenticate Data address, using key A",
         }
     ],
     "AUTDZB": [
         {
             "instr": "AUTDZB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_epx1476202676637.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_epx1476202676637.htm",
             "short": "Authenticate Data address, using key B",
         }
     ],
     "AUTIA": [
         {
             "instr": "AUTIA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
             "short": "Authenticate Instruction address, using key A",
         }
     ],
     "AUTIA1716": [
         {
             "instr": "AUTIA1716",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
             "short": "Authenticate Instruction address, using key A",
         }
     ],
     "AUTIASP": [
         {
             "instr": "AUTIASP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
             "short": "Authenticate Instruction address, using key A",
         }
     ],
     "AUTIAZ": [
         {
             "instr": "AUTIAZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
             "short": "Authenticate Instruction address, using key A",
         }
     ],
     "AUTIB": [
         {
             "instr": "AUTIB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
             "short": "Authenticate Instruction address, using key B",
         }
     ],
     "AUTIB1716": [
         {
             "instr": "AUTIB1716",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
             "short": "Authenticate Instruction address, using key B",
         }
     ],
     "AUTIBSP": [
         {
             "instr": "AUTIBSP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
             "short": "Authenticate Instruction address, using key B",
         }
     ],
     "AUTIBZ": [
         {
             "instr": "AUTIBZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
             "short": "Authenticate Instruction address, using key B",
         }
     ],
     "AUTIZA": [
         {
             "instr": "AUTIZA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rmi1476202677017.htm",
             "short": "Authenticate Instruction address, using key A",
         }
     ],
     "AUTIZB": [
         {
             "instr": "AUTIZB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lru1476202677407.htm",
             "short": "Authenticate Instruction address, using key B",
         }
     ],
     "B": [
         {
             "instr": "B",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897650614.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897650614.htm",
             "short": "Branch",
         }
     ],
     "B.cond": [
         {
             "instr": "B.cond",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897650204.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897650204.htm",
             "short": "Branch conditionally",
         }
     ],
     "BFC": [
         {
             "instr": "BFC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cka1476202679437.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cka1476202679437.htm",
             "short": "Bitfield Clear, leaving other bits unchanged",
         }
     ],
     "BFI": [
         {
             "instr": "BFI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651014.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651014.htm",
             "short": "Bitfield Insert",
         }
     ],
     "BFM": [
         {
             "instr": "BFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651414.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651414.htm",
             "short": "Bitfield Move",
         }
     ],
     "BFXIL": [
         {
             "instr": "BFXIL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651834.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897651834.htm",
             "short": "Bitfield extract and insert at low end",
         }
     ],
     "BIC": [
         {
             "instr": "BIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897652244.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897652244.htm",
             "short": "Bitwise Bit Clear (shifted register)",
         },
         {
             "instr": "BIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897490745.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897490745.htm",
             "short": "Bitwise bit Clear (vector, immediate)",
         },
         {
             "instr": "BIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897491335.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897491335.htm",
             "short": "Bitwise bit Clear (vector, register)",
         },
     ],
     "BICS": [
         {
             "instr": "BICS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897652644.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897652644.htm",
             "short": "Bitwise Bit Clear (shifted register), setting flags",
         }
     ],
     "BIF": [
         {
             "instr": "BIF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897491825.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897491825.htm",
             "short": "Bitwise Insert if False",
         }
     ],
     "BIT": [
         {
             "instr": "BIT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897492375.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897492375.htm",
             "short": "Bitwise Insert if True",
         }
     ],
     "BL": [
         {
             "instr": "BL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653074.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653074.htm",
             "short": "Branch with Link",
         }
     ],
     "BLR": [
         {
             "instr": "BLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653454.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653454.htm",
             "short": "Branch with Link to Register",
         }
     ],
     "BLRAA": [
         {
             "instr": "BLRAA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
             "short": "Branch with Link to Register, with pointer authentication",
         }
     ],
     "BLRAAZ": [
         {
             "instr": "BLRAAZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
             "short": "Branch with Link to Register, with pointer authentication",
         }
     ],
     "BLRAB": [
         {
             "instr": "BLRAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
             "short": "Branch with Link to Register, with pointer authentication",
         }
     ],
     "BLRABZ": [
         {
             "instr": "BLRABZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zwh1476202686019.htm",
             "short": "Branch with Link to Register, with pointer authentication",
         }
     ],
     "BR": [
         {
             "instr": "BR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653894.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897653894.htm",
             "short": "Branch to Register",
         }
     ],
     "BRAA": [
         {
             "instr": "BRAA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
             "short": "Branch to Register, with pointer authentication",
         }
     ],
     "BRAAZ": [
         {
             "instr": "BRAAZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
             "short": "Branch to Register, with pointer authentication",
         }
     ],
     "BRAB": [
         {
             "instr": "BRAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
             "short": "Branch to Register, with pointer authentication",
         }
     ],
     "BRABZ": [
         {
             "instr": "BRABZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hgj1476202687129.html",
             "short": "Branch to Register, with pointer authentication",
         }
     ],
     "BRK": [
         {
             "instr": "BRK",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897654274.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897654274.htm",
             "short": "Breakpoint instruction",
         }
     ],
     "BSL": [
         {
             "instr": "BSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897492865.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897492865.htm",
             "short": "Bitwise Select",
         }
     ],
     "CAS": [
         {
             "instr": "CAS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
         {
             "instr": "CAS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
     ],
     "CASA": [
         {
             "instr": "CASA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         }
     ],
     "CASAB": [
         {
             "instr": "CASAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
             "short": "Compare and Swap byte in memory",
         }
     ],
     "CASAH": [
         {
             "instr": "CASAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
             "short": "Compare and Swap halfword in memory",
         }
     ],
     "CASAL": [
         {
             "instr": "CASAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
         {
             "instr": "CASAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
     ],
     "CASALB": [
         {
             "instr": "CASALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
             "short": "Compare and Swap byte in memory",
         }
     ],
     "CASALH": [
         {
             "instr": "CASALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
             "short": "Compare and Swap halfword in memory",
         }
     ],
     "CASB": [
         {
             "instr": "CASB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
             "short": "Compare and Swap byte in memory",
         }
     ],
     "CASH": [
         {
             "instr": "CASH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
             "short": "Compare and Swap halfword in memory",
         }
     ],
     "CASL": [
         {
             "instr": "CASL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
         {
             "instr": "CASL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bzf1476202789613.htm",
             "short": "Compare and Swap word or doubleword in memory",
         },
     ],
     "CASLB": [
         {
             "instr": "CASLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_gmf1476202790003.htm",
             "short": "Compare and Swap byte in memory",
         }
     ],
     "CASLH": [
         {
             "instr": "CASLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aoa1476202790353.htm",
             "short": "Compare and Swap halfword in memory",
         }
     ],
     "CASP": [
         {
             "instr": "CASP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
         {
             "instr": "CASP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
     ],
     "CASPA": [
         {
             "instr": "CASPA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         }
     ],
     "CASPAL": [
         {
             "instr": "CASPAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
         {
             "instr": "CASPAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
     ],
     "CASPL": [
         {
             "instr": "CASPL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
         {
             "instr": "CASPL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_yhp1476202790683.htm",
             "short": "Compare and Swap Pair of words or doublewords in memory",
         },
     ],
     "CBNZ": [
         {
             "instr": "CBNZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897654664.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897654664.htm",
             "short": "Compare and Branch on Nonzero",
         }
     ],
     "CBZ": [
         {
             "instr": "CBZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655065.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655065.htm",
             "short": "Compare and Branch on Zero",
         }
     ],
     "CCMN": [
         {
             "instr": "CCMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655425.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655425.htm",
             "short": "Conditional Compare Negative (immediate)",
         },
         {
             "instr": "CCMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655835.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897655835.htm",
             "short": "Conditional Compare Negative (register)",
         },
     ],
     "CCMP": [
         {
             "instr": "CCMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897656225.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897656225.htm",
             "short": "Conditional Compare (immediate)",
         },
         {
             "instr": "CCMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897656625.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897656625.htm",
             "short": "Conditional Compare (register)",
         },
     ],
     "CINC": [
         {
             "instr": "CINC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657035.htm",
             "short": "Conditional Increment",
         }
     ],
     "CINV": [
         {
             "instr": "CINV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657455.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657455.htm",
             "short": "Conditional Invert",
         }
     ],
     "CLREX": [
         {
             "instr": "CLREX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657895.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897657895.htm",
             "short": "Clear Exclusive",
         }
     ],
     "CLS": [
         {
             "instr": "CLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897658265.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897658265.htm",
             "short": "Count leading sign bits",
         },
         {
             "instr": "CLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897493425.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897493425.htm",
             "short": "Count Leading Sign bits (vector)",
         },
     ],
     "CLZ": [
         {
             "instr": "CLZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897658715.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897658715.htm",
             "short": "Count leading zero bits",
         },
         {
             "instr": "CLZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897493875.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897493875.htm",
             "short": "Count Leading Zero bits (vector)",
         },
     ],
     "CMEQ": [
         {
             "instr": "CMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897441322.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897441322.htm",
             "short": "Compare bitwise Equal (vector)",
         },
         {
             "instr": "CMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897441712.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897441712.htm",
             "short": "Compare bitwise Equal to zero (vector)",
         },
         {
             "instr": "CMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897494285.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897494285.htm",
             "short": "Compare bitwise Equal (vector)",
         },
         {
             "instr": "CMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897494815.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897494815.htm",
             "short": "Compare bitwise Equal to zero (vector)",
         },
     ],
     "CMGE": [
         {
             "instr": "CMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442112.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442112.htm",
             "short": "Compare signed Greater than or Equal (vector)",
         },
         {
             "instr": "CMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442492.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442492.htm",
             "short": "Compare signed Greater than or Equal to zero (vector)",
         },
         {
             "instr": "CMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897495295.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897495295.htm",
             "short": "Compare signed Greater than or Equal (vector)",
         },
         {
             "instr": "CMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897495775.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897495775.htm",
             "short": "Compare signed Greater than or Equal to zero (vector)",
         },
     ],
     "CMGT": [
         {
             "instr": "CMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442882.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897442882.htm",
             "short": "Compare signed Greater than (vector)",
         },
         {
             "instr": "CMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897443282.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897443282.htm",
             "short": "Compare signed Greater than zero (vector)",
         },
         {
             "instr": "CMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897496325.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897496325.htm",
             "short": "Compare signed Greater than (vector)",
         },
         {
             "instr": "CMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897496885.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897496885.htm",
             "short": "Compare signed Greater than zero (vector)",
         },
     ],
     "CMHI": [
         {
             "instr": "CMHI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897443692.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897443692.htm",
             "short": "Compare unsigned Higher (vector)",
         },
         {
             "instr": "CMHI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897497415.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897497415.htm",
             "short": "Compare unsigned Higher (vector)",
         },
     ],
     "CMHS": [
         {
             "instr": "CMHS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444092.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444092.htm",
             "short": "Compare unsigned Higher or Same (vector)",
         },
         {
             "instr": "CMHS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897497905.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897497905.htm",
             "short": "Compare unsigned Higher or Same (vector)",
         },
     ],
     "CMLE": [
         {
             "instr": "CMLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444512.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444512.htm",
             "short": "Compare signed Less than or Equal to zero (vector)",
         },
         {
             "instr": "CMLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897498955.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897498955.htm",
             "short": "Compare signed Less than or Equal to zero (vector)",
         },
     ],
     "CMLT": [
         {
             "instr": "CMLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444922.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897444922.htm",
             "short": "Compare signed Less than zero (vector)",
         },
         {
             "instr": "CMLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897499495.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897499495.htm",
             "short": "Compare signed Less than zero (vector)",
         },
     ],
     "CMN": [
         {
             "instr": "CMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659105.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659105.htm",
             "short": "Compare Negative (extended register)",
         },
         {
             "instr": "CMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659565.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659565.htm",
             "short": "Compare Negative (immediate)",
         },
         {
             "instr": "CMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659975.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897659975.htm",
             "short": "Compare Negative (shifted register)",
         },
     ],
     "CMP": [
         {
             "instr": "CMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897660455.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897660455.htm",
             "short": "Compare (extended register)",
         },
         {
             "instr": "CMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897660935.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897660935.htm",
             "short": "Compare (immediate)",
         },
         {
             "instr": "CMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897661385.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897661385.htm",
             "short": "Compare (shifted register)",
         },
     ],
     "CMTST": [
         {
             "instr": "CMTST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897445342.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897445342.htm",
             "short": "Compare bitwise Test bits nonzero (vector)",
         },
         {
             "instr": "CMTST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500035.htm",
             "short": "Compare bitwise Test bits nonzero (vector)",
         },
     ],
     "CNEG": [
         {
             "instr": "CNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897661805.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897661805.htm",
             "short": "Conditional Negate",
         }
     ],
     "CNT": [
         {
             "instr": "CNT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500465.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500465.htm",
             "short": "Population Count per byte",
         }
     ],
     "CRC32B": [
         {
             "instr": "CRC32B",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
             "short": "CRC32checksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32CB": [
         {
             "instr": "CRC32CB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
             "short": "CRC32Cchecksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32CH": [
         {
             "instr": "CRC32CH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
             "short": "CRC32Cchecksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32CW": [
         {
             "instr": "CRC32CW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
             "short": "CRC32Cchecksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32CX": [
         {
             "instr": "CRC32CX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662775.htm",
             "short": "CRC32Cchecksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32H": [
         {
             "instr": "CRC32H",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
             "short": "CRC32checksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32W": [
         {
             "instr": "CRC32W",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
             "short": "CRC32checksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CRC32X": [
         {
             "instr": "CRC32X",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897662265.htm",
             "short": "CRC32checksum performs a cyclic redundancy check (CRC) calculation on a value held in a general-purpose register",
         }
     ],
     "CSEL": [
         {
             "instr": "CSEL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897663325.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897663325.htm",
             "short": "Conditional Select",
         }
     ],
     "CSET": [
         {
             "instr": "CSET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664015.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664015.htm",
             "short": "Conditional Set",
         }
     ],
     "CSETM": [
         {
             "instr": "CSETM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664525.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664525.htm",
             "short": "Conditional Set Mask",
         }
     ],
     "CSINC": [
         {
             "instr": "CSINC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664975.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897664975.htm",
             "short": "Conditional Select Increment",
         }
     ],
     "CSINV": [
         {
             "instr": "CSINV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897665525.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897665525.htm",
             "short": "Conditional Select Invert",
         }
     ],
     "CSNEG": [
         {
             "instr": "CSNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897666075.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897666075.htm",
             "short": "Conditional Select Negation",
         }
     ],
     "DC": [
         {
             "instr": "DC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897666605.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897666605.htm",
             "short": "Data Cache operation",
         }
     ],
     "DCPS1": [
         {
             "instr": "DCPS1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897667125.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897667125.htm",
             "short": "Debug Change PE State to EL1",
         }
     ],
     "DCPS2": [
         {
             "instr": "DCPS2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897667595.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897667595.htm",
             "short": "Debug Change PE State to EL2",
         }
     ],
     "DCPS3": [
         {
             "instr": "DCPS3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668035.htm",
             "short": "Debug Change PE State to EL3",
         }
     ],
     "DMB": [
         {
             "instr": "DMB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668415.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668415.htm",
             "short": "Data Memory Barrier",
         }
     ],
     "DRPS": [
         {
             "instr": "DRPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668955.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897668955.htm",
             "short": "Debug restore process state",
         }
     ],
     "DSB": [
         {
             "instr": "DSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897669375.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897669375.htm",
             "short": "Data Synchronization Barrier",
         }
     ],
     "DUP": [
         {
             "instr": "DUP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897445742.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897445742.htm",
             "short": "Duplicate vector element to scalar",
         },
         {
             "instr": "DUP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500875.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897500875.htm",
             "short": "vector",
         },
         {
             "instr": "DUP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897501315.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897501315.htm",
             "short": "Duplicate general-purpose register to vector",
         },
     ],
     "EON": [
         {
             "instr": "EON",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897669975.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897669975.htm",
             "short": "Bitwise Exclusive OR NOT (shifted register)",
         }
     ],
     "EOR": [
         {
             "instr": "EOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897670485.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897670485.htm",
             "short": "Bitwise Exclusive OR (immediate)",
         },
         {
             "instr": "EOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897670995.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897670995.htm",
             "short": "Bitwise Exclusive OR (shifted register)",
         },
         {
             "instr": "EOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897501735.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897501735.htm",
             "short": "Bitwise Exclusive OR (vector)",
         },
     ],
     "ERET": [
         {
             "instr": "ERET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897671546.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897671546.htm",
             "short": "Returns from an exception",
         }
     ],
     "ERETAA": [
         {
             "instr": "ERETAA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nps1476202716430.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nps1476202716430.htm",
             "short": "Exception Return, with pointer authentication",
         }
     ],
     "ERETAB": [
         {
             "instr": "ERETAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nps1476202716430.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nps1476202716430.htm",
             "short": "Exception Return, with pointer authentication",
         }
     ],
     "ESB": [
         {
             "instr": "ESB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_phq1476202716780.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_phq1476202716780.htm",
             "short": "Error Synchronization Barrier",
         }
     ],
     "EXT": [
         {
             "instr": "EXT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502155.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502155.htm",
             "short": "Extract vector from pair of vectors",
         }
     ],
     "EXTR": [
         {
             "instr": "EXTR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672006.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672006.htm",
             "short": "Extract register",
         }
     ],
     "FABD": [
         {
             "instr": "FABD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446162.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446162.htm",
             "short": "Floating-point Absolute Difference (vector)",
         },
         {
             "instr": "FABD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502565.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502565.htm",
             "short": "Floating-point Absolute Difference (vector)",
         },
     ],
     "FABS": [
         {
             "instr": "FABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897617402.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897617402.htm",
             "short": "Floating-point Absolute value (scalar)",
         },
         {
             "instr": "FABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502955.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897502955.htm",
             "short": "Floating-point Absolute value (vector)",
         },
     ],
     "FACGE": [
         {
             "instr": "FACGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446512.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446512.htm",
             "short": "Floating-point Absolute Compare Greater than or Equal (vector)",
         },
         {
             "instr": "FACGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897503355.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897503355.htm",
             "short": "Floating-point Absolute Compare Greater than or Equal (vector)",
         },
     ],
     "FACGT": [
         {
             "instr": "FACGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446902.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897446902.htm",
             "short": "Floating-point Absolute Compare Greater than (vector)",
         },
         {
             "instr": "FACGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897503765.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897503765.htm",
             "short": "Floating-point Absolute Compare Greater than (vector)",
         },
     ],
     "FADD": [
         {
             "instr": "FADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897617982.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897617982.htm",
             "short": "Floating-point Add (scalar)",
         },
         {
             "instr": "FADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897504205.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897504205.htm",
             "short": "Floating-point Add (vector)",
         },
     ],
     "FADDP": [
         {
             "instr": "FADDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897447312.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897447312.htm",
             "short": "Floating-point Add Pair of elements (scalar)",
         },
         {
             "instr": "FADDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897504615.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897504615.htm",
             "short": "Floating-point Add Pairwise (vector)",
         },
     ],
     "FCADD": [
         {
             "instr": "FCADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mgn1476203041156.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mgn1476203041156.htm",
             "short": "Floating-point Complex Add",
         }
     ],
     "FCCMP": [
         {
             "instr": "FCCMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897618502.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897618502.htm",
             "short": "Floating-point Conditional quiet Compare (scalar)",
         }
     ],
     "FCCMPE": [
         {
             "instr": "FCCMPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897618962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897618962.htm",
             "short": "Floating-point Conditional signaling Compare (scalar)",
         }
     ],
     "FCMEQ": [
         {
             "instr": "FCMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897447742.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897447742.htm",
             "short": "Floating-point Compare Equal (vector)",
         },
         {
             "instr": "FCMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448152.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448152.htm",
             "short": "Floating-point Compare Equal to zero (vector)",
         },
         {
             "instr": "FCMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505016.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505016.htm",
             "short": "Floating-point Compare Equal (vector)",
         },
         {
             "instr": "FCMEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505426.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505426.htm",
             "short": "Floating-point Compare Equal to zero (vector)",
         },
     ],
     "FCMGE": [
         {
             "instr": "FCMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448532.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448532.htm",
             "short": "Floating-point Compare Greater than or Equal (vector)",
         },
         {
             "instr": "FCMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448952.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897448952.htm",
             "short": "Floating-point Compare Greater than or Equal to zero (vector)",
         },
         {
             "instr": "FCMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505866.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897505866.htm",
             "short": "Floating-point Compare Greater than or Equal (vector)",
         },
         {
             "instr": "FCMGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897506276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897506276.htm",
             "short": "Floating-point Compare Greater than or Equal to zero (vector)",
         },
     ],
     "FCMGT": [
         {
             "instr": "FCMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897449342.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897449342.htm",
             "short": "Floating-point Compare Greater than (vector)",
         },
         {
             "instr": "FCMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897449712.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897449712.htm",
             "short": "Floating-point Compare Greater than zero (vector)",
         },
         {
             "instr": "FCMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897506676.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897506676.htm",
             "short": "Floating-point Compare Greater than (vector)",
         },
         {
             "instr": "FCMGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507086.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507086.htm",
             "short": "Floating-point Compare Greater than zero (vector)",
         },
     ],
     "FCMLA": [
         {
             "instr": "FCMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dfq1476202939796.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dfq1476202939796.htm",
             "short": "Floating-point Complex Multiply Accumulate (by element)",
         },
         {
             "instr": "FCMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qlf1476203046046.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qlf1476203046046.htm",
             "short": "Floating-point Complex Multiply Accumulate",
         },
     ],
     "FCMLE": [
         {
             "instr": "FCMLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450092.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450092.htm",
             "short": "Floating-point Compare Less than or Equal to zero (vector)",
         },
         {
             "instr": "FCMLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507506.htm",
             "short": "Floating-point Compare Less than or Equal to zero (vector)",
         },
     ],
     "FCMLT": [
         {
             "instr": "FCMLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450482.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450482.htm",
             "short": "Floating-point Compare Less than zero (vector)",
         },
         {
             "instr": "FCMLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507896.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897507896.htm",
             "short": "Floating-point Compare Less than zero (vector)",
         },
     ],
     "FCMP": [
         {
             "instr": "FCMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897619442.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897619442.htm",
             "short": "Floating-point quiet Compare (scalar)",
         }
     ],
     "FCMPE": [
         {
             "instr": "FCMPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897619882.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897619882.htm",
             "short": "Floating-point signaling Compare (scalar)",
         }
     ],
     "FCSEL": [
         {
             "instr": "FCSEL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897620402.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897620402.htm",
             "short": "Floating-point Conditional Select (scalar)",
         }
     ],
     "FCVT": [
         {
             "instr": "FCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897620942.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897620942.htm",
             "short": "Floating-point Convert precision (scalar)",
         }
     ],
     "FCVTAS": [
         {
             "instr": "FCVTAS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897621453.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897621453.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to Away (scalar)",
         },
         {
             "instr": "FCVTAS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450912.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897450912.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to Away (vector)",
         },
         {
             "instr": "FCVTAS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897508276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897508276.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to Away (vector)",
         },
     ],
     "FCVTAU": [
         {
             "instr": "FCVTAU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897621873.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897621873.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to Away (scalar)",
         },
         {
             "instr": "FCVTAU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897451312.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897451312.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to Away (vector)",
         },
         {
             "instr": "FCVTAU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897508656.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897508656.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to Away (vector)",
         },
     ],
     "FCVTL": [
         {
             "instr": "FCVTL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509086.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509086.htm",
             "short": "Floating-point Convert to higher precision Long (vector)",
         }
     ],
     "FCVTL2": [
         {
             "instr": "FCVTL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509086.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509086.htm",
             "short": "Floating-point Convert to higher precision Long (vector)",
         }
     ],
     "FCVTMS": [
         {
             "instr": "FCVTMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897622273.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897622273.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Minus infinity (scalar)",
         },
         {
             "instr": "FCVTMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897451692.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897451692.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Minus infinity (vector)",
         },
         {
             "instr": "FCVTMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509536.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509536.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Minus infinity (vector)",
         },
     ],
     "FCVTMU": [
         {
             "instr": "FCVTMU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897622683.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897622683.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Minus infinity (scalar)",
         },
         {
             "instr": "FCVTMU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452062.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452062.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Minus infinity (vector)",
         },
         {
             "instr": "FCVTMU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509946.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897509946.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Minus infinity (vector)",
         },
     ],
     "FCVTN": [
         {
             "instr": "FCVTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510386.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510386.htm",
             "short": "Floating-point Convert to lower precision Narrow (vector)",
         }
     ],
     "FCVTN2": [
         {
             "instr": "FCVTN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510386.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510386.htm",
             "short": "Floating-point Convert to lower precision Narrow (vector)",
         }
     ],
     "FCVTNS": [
         {
             "instr": "FCVTNS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623093.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623093.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to even (scalar)",
         },
         {
             "instr": "FCVTNS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452432.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452432.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to even (vector)",
         },
         {
             "instr": "FCVTNS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510806.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897510806.htm",
             "short": "Floating-point Convert to Signed integer, rounding to nearest with ties to even (vector)",
         },
     ],
     "FCVTNU": [
         {
             "instr": "FCVTNU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623513.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623513.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to even (scalar)",
         },
         {
             "instr": "FCVTNU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452822.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897452822.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to even (vector)",
         },
         {
             "instr": "FCVTNU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897511226.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897511226.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding to nearest with ties to even (vector)",
         },
     ],
     "FCVTPS": [
         {
             "instr": "FCVTPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623923.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897623923.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Plus infinity (scalar)",
         },
         {
             "instr": "FCVTPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897453202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897453202.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Plus infinity (vector)",
         },
         {
             "instr": "FCVTPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897511636.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897511636.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Plus infinity (vector)",
         },
     ],
     "FCVTPU": [
         {
             "instr": "FCVTPU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897624353.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897624353.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Plus infinity (scalar)",
         },
         {
             "instr": "FCVTPU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897453612.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897453612.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Plus infinity (vector)",
         },
         {
             "instr": "FCVTPU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512026.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512026.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Plus infinity (vector)",
         },
     ],
     "FCVTXN": [
         {
             "instr": "FCVTXN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454022.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454022.htm",
             "short": "Floating-point Convert to lower precision Narrow, rounding to odd (vector)",
         },
         {
             "instr": "FCVTXN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512426.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512426.htm",
             "short": "Floating-point Convert to lower precision Narrow, rounding to odd (vector)",
         },
     ],
     "FCVTXN2": [
         {
             "instr": "FCVTXN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512426.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512426.htm",
             "short": "Floating-point Convert to lower precision Narrow, rounding to odd (vector)",
         }
     ],
     "FCVTZS": [
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897624753.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897624753.htm",
             "short": "Floating-point Convert to Signed fixed-point, rounding toward Zero (scalar)",
         },
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897625203.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897625203.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Zero (scalar)",
         },
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454412.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454412.htm",
             "short": "Floating-point Convert to Signed fixed-point, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454813.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897454813.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512846.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897512846.htm",
             "short": "Floating-point Convert to Signed fixed-point, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897513276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897513276.htm",
             "short": "Floating-point Convert to Signed integer, rounding toward Zero (vector)",
         },
     ],
     "FCVTZU": [
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897625623.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897625623.htm",
             "short": "Floating-point Convert to Unsigned fixed-point, rounding toward Zero (scalar)",
         },
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626053.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626053.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Zero (scalar)",
         },
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897455213.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897455213.htm",
             "short": "Floating-point Convert to Unsigned fixed-point, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897455603.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897455603.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897513666.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897513666.htm",
             "short": "Floating-point Convert to Unsigned fixed-point, rounding toward Zero (vector)",
         },
         {
             "instr": "FCVTZU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514056.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514056.htm",
             "short": "Floating-point Convert to Unsigned integer, rounding toward Zero (vector)",
         },
     ],
     "FDIV": [
         {
             "instr": "FDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626513.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626513.htm",
             "short": "Floating-point Divide (scalar)",
         },
         {
             "instr": "FDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514446.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514446.htm",
             "short": "Floating-point Divide (vector)",
         },
     ],
     "FJCVTZS": [
         {
             "instr": "FJCVTZS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hko1477562192868.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hko1477562192868.html",
             "short": "Floating-point Javascript Convert to Signed fixed-point, rounding toward Zero",
         }
     ],
     "FMADD": [
         {
             "instr": "FMADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626943.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897626943.htm",
             "short": "Floating-point fused Multiply-Add (scalar)",
         }
     ],
     "FMAX": [
         {
             "instr": "FMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897627373.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897627373.htm",
             "short": "Floating-point Maximum (scalar)",
         },
         {
             "instr": "FMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514836.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897514836.htm",
             "short": "Floating-point Maximum (vector)",
         },
     ],
     "FMAXNM": [
         {
             "instr": "FMAXNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897627763.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897627763.htm",
             "short": "Floating-point Maximum Number (scalar)",
         },
         {
             "instr": "FMAXNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897515246.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897515246.htm",
             "short": "Floating-point Maximum Number (vector)",
         },
     ],
     "FMAXNMP": [
         {
             "instr": "FMAXNMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456003.htm",
             "short": "Floating-point Maximum Number of Pair of elements (scalar)",
         },
         {
             "instr": "FMAXNMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897515626.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897515626.htm",
             "short": "Floating-point Maximum Number Pairwise (vector)",
         },
     ],
     "FMAXNMV": [
         {
             "instr": "FMAXNMV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516016.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516016.htm",
             "short": "Floating-point Maximum Number across Vector",
         }
     ],
     "FMAXP": [
         {
             "instr": "FMAXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456393.htm",
             "short": "Floating-point Maximum of Pair of elements (scalar)",
         },
         {
             "instr": "FMAXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516506.htm",
             "short": "Floating-point Maximum Pairwise (vector)",
         },
     ],
     "FMAXV": [
         {
             "instr": "FMAXV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516896.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897516896.htm",
             "short": "Floating-point Maximum across Vector",
         }
     ],
     "FMIN": [
         {
             "instr": "FMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897628203.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897628203.htm",
             "short": "Floating-point Minimum (scalar)",
         },
         {
             "instr": "FMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897517286.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897517286.htm",
             "short": "Floating-point minimum (vector)",
         },
     ],
     "FMINNM": [
         {
             "instr": "FMINNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897628613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897628613.htm",
             "short": "Floating-point Minimum Number (scalar)",
         },
         {
             "instr": "FMINNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897517666.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897517666.htm",
             "short": "Floating-point Minimum Number (vector)",
         },
     ],
     "FMINNMP": [
         {
             "instr": "FMINNMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456773.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897456773.htm",
             "short": "Floating-point Minimum Number of Pair of elements (scalar)",
         },
         {
             "instr": "FMINNMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518046.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518046.htm",
             "short": "Floating-point Minimum Number Pairwise (vector)",
         },
     ],
     "FMINNMV": [
         {
             "instr": "FMINNMV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518436.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518436.htm",
             "short": "Floating-point Minimum Number across Vector",
         }
     ],
     "FMINP": [
         {
             "instr": "FMINP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897457193.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897457193.htm",
             "short": "Floating-point Minimum of Pair of elements (scalar)",
         },
         {
             "instr": "FMINP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518826.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897518826.htm",
             "short": "Floating-point Minimum Pairwise (vector)",
         },
     ],
     "FMINV": [
         {
             "instr": "FMINV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897519266.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897519266.htm",
             "short": "Floating-point Minimum across Vector",
         }
     ],
     "FMLA": [
         {
             "instr": "FMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897457593.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897457593.htm",
             "short": "Floating-point fused Multiply-Add to accumulator (by element)",
         },
         {
             "instr": "FMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897519636.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897519636.htm",
             "short": "Floating-point fused Multiply-Add to accumulator (by element)",
         },
         {
             "instr": "FMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897520046.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897520046.htm",
             "short": "Floating-point fused Multiply-Add to accumulator (vector)",
         },
     ],
     "FMLS": [
         {
             "instr": "FMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458023.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458023.htm",
             "short": "Floating-point fused Multiply-Subtract from accumulator (by element)",
         },
         {
             "instr": "FMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897520946.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897520946.htm",
             "short": "Floating-point fused Multiply-Subtract from accumulator (by element)",
         },
         {
             "instr": "FMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897521387.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897521387.htm",
             "short": "Floating-point fused Multiply-Subtract from accumulator (vector)",
         },
     ],
     "FMOV": [
         {
             "instr": "FMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629003.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629003.htm",
             "short": "Floating-point Move register without conversion",
         },
         {
             "instr": "FMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629393.htm",
             "short": "Floating-point Move to or from general-purpose register without conversion",
         },
         {
             "instr": "FMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629843.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897629843.htm",
             "short": "Floating-point move immediate (scalar)",
         },
         {
             "instr": "FMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897521767.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897521767.htm",
             "short": "Floating-point move immediate (vector)",
         },
     ],
     "FMSUB": [
         {
             "instr": "FMSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897630223.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897630223.htm",
             "short": "Floating-point Fused Multiply-Subtract (scalar)",
         }
     ],
     "FMUL": [
         {
             "instr": "FMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897630633.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897630633.htm",
             "short": "Floating-point Multiply (scalar)",
         },
         {
             "instr": "FMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458413.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458413.htm",
             "short": "Floating-point Multiply (by element)",
         },
         {
             "instr": "FMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522147.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522147.htm",
             "short": "Floating-point Multiply (by element)",
         },
         {
             "instr": "FMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522567.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522567.htm",
             "short": "Floating-point Multiply (vector)",
         },
     ],
     "FMULX": [
         {
             "instr": "FMULX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458813.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897458813.htm",
             "short": "Floating-point Multiply extended (by element)",
         },
         {
             "instr": "FMULX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897459253.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897459253.htm",
             "short": "Floating-point Multiply extended",
         },
         {
             "instr": "FMULX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522957.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897522957.htm",
             "short": "Floating-point Multiply extended (by element)",
         },
         {
             "instr": "FMULX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897523417.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897523417.htm",
             "short": "Floating-point Multiply extended",
         },
     ],
     "FNEG": [
         {
             "instr": "FNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631043.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631043.htm",
             "short": "Floating-point Negate (scalar)",
         },
         {
             "instr": "FNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897523817.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897523817.htm",
             "short": "Floating-point Negate (vector)",
         },
     ],
     "FNMADD": [
         {
             "instr": "FNMADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631413.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631413.htm",
             "short": "Floating-point Negated fused Multiply-Add (scalar)",
         }
     ],
     "FNMSUB": [
         {
             "instr": "FNMSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631823.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897631823.htm",
             "short": "Floating-point Negated fused Multiply-Subtract (scalar)",
         }
     ],
     "FNMUL": [
         {
             "instr": "FNMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897632233.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897632233.htm",
             "short": "Floating-point Multiply-Negate (scalar)",
         }
     ],
     "FRECPE": [
         {
             "instr": "FRECPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897459633.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897459633.htm",
             "short": "Floating-point Reciprocal Estimate",
         },
         {
             "instr": "FRECPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524207.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524207.htm",
             "short": "Floating-point Reciprocal Estimate",
         },
     ],
     "FRECPS": [
         {
             "instr": "FRECPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897460033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897460033.htm",
             "short": "Floating-point Reciprocal Step",
         },
         {
             "instr": "FRECPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524617.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524617.htm",
             "short": "Floating-point Reciprocal Step",
         },
     ],
     "FRECPX": [
         {
             "instr": "FRECPX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xca1476203080522.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xca1476203080522.htm",
             "short": "Floating-point Reciprocal exponent (scalar)",
         }
     ],
     "FRINTA": [
         {
             "instr": "FRINTA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897632633.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897632633.htm",
             "short": "Floating-point Round to Integral, to nearest with ties to Away (scalar)",
         },
         {
             "instr": "FRINTA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524987.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897524987.htm",
             "short": "Floating-point Round to Integral, to nearest with ties to Away (vector)",
         },
     ],
     "FRINTI": [
         {
             "instr": "FRINTI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633023.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633023.htm",
             "short": "Floating-point Round to Integral, using current rounding mode (scalar)",
         },
         {
             "instr": "FRINTI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897525377.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897525377.htm",
             "short": "Floating-point Round to Integral, using current rounding mode (vector)",
         },
     ],
     "FRINTM": [
         {
             "instr": "FRINTM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633393.htm",
             "short": "Floating-point Round to Integral, toward Minus infinity (scalar)",
         },
         {
             "instr": "FRINTM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897525767.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897525767.htm",
             "short": "Floating-point Round to Integral, toward Minus infinity (vector)",
         },
     ],
     "FRINTN": [
         {
             "instr": "FRINTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633803.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897633803.htm",
             "short": "Floating-point Round to Integral, to nearest with ties to even (scalar)",
         },
         {
             "instr": "FRINTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526187.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526187.htm",
             "short": "Floating-point Round to Integral, to nearest with ties to even (vector)",
         },
     ],
     "FRINTP": [
         {
             "instr": "FRINTP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897634203.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897634203.htm",
             "short": "Floating-point Round to Integral, toward Plus infinity (scalar)",
         },
         {
             "instr": "FRINTP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526627.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526627.htm",
             "short": "Floating-point Round to Integral, toward Plus infinity (vector)",
         },
     ],
     "FRINTX": [
         {
             "instr": "FRINTX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897634613.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897634613.htm",
             "short": "Floating-point Round to Integral exact, using current rounding mode (scalar)",
         },
         {
             "instr": "FRINTX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526997.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897526997.htm",
             "short": "Floating-point Round to Integral exact, using current rounding mode (vector)",
         },
     ],
     "FRINTZ": [
         {
             "instr": "FRINTZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635033.htm",
             "short": "Floating-point Round to Integral, toward Zero (scalar)",
         },
         {
             "instr": "FRINTZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897527357.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897527357.htm",
             "short": "Floating-point Round to Integral, toward Zero (vector)",
         },
     ],
     "FRSQRTE": [
         {
             "instr": "FRSQRTE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897461313.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897461313.htm",
             "short": "Floating-point Reciprocal Square Root Estimate",
         },
         {
             "instr": "FRSQRTE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897527727.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897527727.htm",
             "short": "Floating-point Reciprocal Square Root Estimate",
         },
     ],
     "FRSQRTS": [
         {
             "instr": "FRSQRTS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897461673.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897461673.htm",
             "short": "Floating-point Reciprocal Square Root Step",
         },
         {
             "instr": "FRSQRTS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897528177.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897528177.htm",
             "short": "Floating-point Reciprocal Square Root Step",
         },
     ],
     "FSQRT": [
         {
             "instr": "FSQRT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635393.htm",
             "short": "Floating-point Square Root (scalar)",
         },
         {
             "instr": "FSQRT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897528617.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897528617.htm",
             "short": "Floating-point Square Root (vector)",
         },
     ],
     "FSUB": [
         {
             "instr": "FSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635823.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897635823.htm",
             "short": "Floating-point Subtract (scalar)",
         },
         {
             "instr": "FSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529017.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529017.htm",
             "short": "Floating-point Subtract (vector)",
         },
     ],
     "HINT": [
         {
             "instr": "HINT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672526.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672526.htm",
             "short": "Hint instruction",
         }
     ],
     "HLT": [
         {
             "instr": "HLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672996.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897672996.htm",
             "short": "Halt instruction",
         }
     ],
     "HVC": [
         {
             "instr": "HVC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897673506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897673506.htm",
             "short": "Hypervisor call to allow OS code to call the Hypervisor",
         }
     ],
     "IC": [
         {
             "instr": "IC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674056.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674056.htm",
             "short": "Instruction Cache operation",
         }
     ],
     "INS": [
         {
             "instr": "INS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529407.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529407.htm",
             "short": "Insert vector element from another vector element",
         },
         {
             "instr": "INS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529787.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897529787.htm",
             "short": "Insert vector element from general-purpose register",
         },
     ],
     "ISB": [
         {
             "instr": "ISB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674546.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674546.htm",
             "short": "Instruction Synchronization Barrier",
         }
     ],
     "LD1": [
         {
             "instr": "LD1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897530197.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897530197.htm",
             "short": "Load multiple single-element structures to one, two, three, or four registers",
         },
         {
             "instr": "LD1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897530747.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897530747.htm",
             "short": "Load one single-element structure to one lane of one register",
         },
     ],
     "LD1R": [
         {
             "instr": "LD1R",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897531187.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897531187.htm",
             "short": "Load one single-element structure and Replicate to all lanes (of one register)",
         }
     ],
     "LD2": [
         {
             "instr": "LD2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897531637.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897531637.htm",
             "short": "Load multiple 2-element structures to two registers",
         },
         {
             "instr": "LD2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532027.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532027.htm",
             "short": "Load single 2-element structure to one lane of two registers",
         },
     ],
     "LD2R": [
         {
             "instr": "LD2R",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532497.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532497.htm",
             "short": "Load single 2-element structure and Replicate to all lanes of two registers",
         }
     ],
     "LD3": [
         {
             "instr": "LD3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532927.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897532927.htm",
             "short": "Load multiple 3-element structures to three registers",
         },
         {
             "instr": "LD3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897533367.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897533367.htm",
             "short": "Load single 3-element structure to one lane of three registers)",
         },
     ],
     "LD3R": [
         {
             "instr": "LD3R",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897533887.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897533887.htm",
             "short": "Load single 3-element structure and Replicate to all lanes of three registers",
         }
     ],
     "LD4": [
         {
             "instr": "LD4",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897534357.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897534357.htm",
             "short": "Load multiple 4-element structures to four registers",
         },
         {
             "instr": "LD4",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897534817.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897534817.htm",
             "short": "Load single 4-element structure to one lane of four registers",
         },
     ],
     "LD4R": [
         {
             "instr": "LD4R",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897535277.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897535277.htm",
             "short": "Load single 4-element structure and Replicate to all lanes of four registers",
         }
     ],
     "LDADD": [
         {
             "instr": "LDADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
         {
             "instr": "LDADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
     ],
     "LDADDA": [
         {
             "instr": "LDADDA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         }
     ],
     "LDADDAB": [
         {
             "instr": "LDADDAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
             "short": "Atomic add on byte in memory",
         }
     ],
     "LDADDAH": [
         {
             "instr": "LDADDAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
             "short": "Atomic add on halfword in memory",
         }
     ],
     "LDADDAL": [
         {
             "instr": "LDADDAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
         {
             "instr": "LDADDAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
     ],
     "LDADDALB": [
         {
             "instr": "LDADDALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
             "short": "Atomic add on byte in memory",
         }
     ],
     "LDADDALH": [
         {
             "instr": "LDADDALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
             "short": "Atomic add on halfword in memory",
         }
     ],
     "LDADDB": [
         {
             "instr": "LDADDB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
             "short": "Atomic add on byte in memory",
         }
     ],
     "LDADDH": [
         {
             "instr": "LDADDH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
             "short": "Atomic add on halfword in memory",
         }
     ],
     "LDADDL": [
         {
             "instr": "LDADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
         {
             "instr": "LDADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_alc1476202791033.htm",
             "short": "Atomic add on word or doubleword in memory",
         },
     ],
     "LDADDLB": [
         {
             "instr": "LDADDLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_szm1476202791393.htm",
             "short": "Atomic add on byte in memory",
         }
     ],
     "LDADDLH": [
         {
             "instr": "LDADDLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xbx1476202791723.htm",
             "short": "Atomic add on halfword in memory",
         }
     ],
     "LDAPR": [
         {
             "instr": "LDAPR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xib1476202792053.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xib1476202792053.htm",
             "short": "Load-Acquire RCpc Register",
         }
     ],
     "LDAPRB": [
         {
             "instr": "LDAPRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ulq1476202792413.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ulq1476202792413.htm",
             "short": "Load-Acquire RCpc Register Byte",
         }
     ],
     "LDAPRH": [
         {
             "instr": "LDAPRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xqi1476202792743.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xqi1476202792743.htm",
             "short": "Load-Acquire RCpc Register Halfword",
         }
     ],
     "LDAR": [
         {
             "instr": "LDAR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897397949.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897397949.htm",
             "short": "Load-Acquire Register",
         }
     ],
     "LDARB": [
         {
             "instr": "LDARB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897399439.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897399439.htm",
             "short": "Load-Acquire Register Byte",
         }
     ],
     "LDARH": [
         {
             "instr": "LDARH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897399839.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897399839.htm",
             "short": "Load-Acquire Register Halfword",
         }
     ],
     "LDAXP": [
         {
             "instr": "LDAXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897400799.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897400799.htm",
             "short": "Load-Acquire Exclusive Pair of Registers",
         }
     ],
     "LDAXR": [
         {
             "instr": "LDAXR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897401219.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897401219.htm",
             "short": "Load-Acquire Exclusive Register",
         }
     ],
     "LDAXRB": [
         {
             "instr": "LDAXRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897401689.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897401689.htm",
             "short": "Load-Acquire Exclusive Register Byte",
         }
     ],
     "LDAXRH": [
         {
             "instr": "LDAXRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402109.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402109.htm",
             "short": "Load-Acquire Exclusive Register Halfword",
         }
     ],
     "LDCLR": [
         {
             "instr": "LDCLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
         {
             "instr": "LDCLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
     ],
     "LDCLRA": [
         {
             "instr": "LDCLRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         }
     ],
     "LDCLRAB": [
         {
             "instr": "LDCLRAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
             "short": "Atomic bit clear on byte in memory",
         }
     ],
     "LDCLRAH": [
         {
             "instr": "LDCLRAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
             "short": "Atomic bit clear on halfword in memory",
         }
     ],
     "LDCLRAL": [
         {
             "instr": "LDCLRAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
         {
             "instr": "LDCLRAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
     ],
     "LDCLRALB": [
         {
             "instr": "LDCLRALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
             "short": "Atomic bit clear on byte in memory",
         }
     ],
     "LDCLRALH": [
         {
             "instr": "LDCLRALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
             "short": "Atomic bit clear on halfword in memory",
         }
     ],
     "LDCLRB": [
         {
             "instr": "LDCLRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
             "short": "Atomic bit clear on byte in memory",
         }
     ],
     "LDCLRH": [
         {
             "instr": "LDCLRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
             "short": "Atomic bit clear on halfword in memory",
         }
     ],
     "LDCLRL": [
         {
             "instr": "LDCLRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
         {
             "instr": "LDCLRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mnz1476202798243.htm",
             "short": "Atomic bit clear on word or doubleword in memory",
         },
     ],
     "LDCLRLB": [
         {
             "instr": "LDCLRLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hkm1476202798643.html",
             "short": "Atomic bit clear on byte in memory",
         }
     ],
     "LDCLRLH": [
         {
             "instr": "LDCLRLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydu1476202799035.htm",
             "short": "Atomic bit clear on halfword in memory",
         }
     ],
     "LDEOR": [
         {
             "instr": "LDEOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
         {
             "instr": "LDEOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
     ],
     "LDEORA": [
         {
             "instr": "LDEORA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         }
     ],
     "LDEORAB": [
         {
             "instr": "LDEORAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
             "short": "Atomic exclusive OR on byte in memory",
         }
     ],
     "LDEORAH": [
         {
             "instr": "LDEORAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
             "short": "Atomic exclusive OR on halfword in memory",
         }
     ],
     "LDEORAL": [
         {
             "instr": "LDEORAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
         {
             "instr": "LDEORAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
     ],
     "LDEORALB": [
         {
             "instr": "LDEORALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
             "short": "Atomic exclusive OR on byte in memory",
         }
     ],
     "LDEORALH": [
         {
             "instr": "LDEORALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
             "short": "Atomic exclusive OR on halfword in memory",
         }
     ],
     "LDEORB": [
         {
             "instr": "LDEORB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
             "short": "Atomic exclusive OR on byte in memory",
         }
     ],
     "LDEORH": [
         {
             "instr": "LDEORH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
             "short": "Atomic exclusive OR on halfword in memory",
         }
     ],
     "LDEORL": [
         {
             "instr": "LDEORL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
         {
             "instr": "LDEORL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_skg1476202799405.htm",
             "short": "Atomic exclusive OR on word or doubleword in memory",
         },
     ],
     "LDEORLB": [
         {
             "instr": "LDEORLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xed1476202799795.htm",
             "short": "Atomic exclusive OR on byte in memory",
         }
     ],
     "LDEORLH": [
         {
             "instr": "LDEORLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/jet1476202800155.html",
             "short": "Atomic exclusive OR on halfword in memory",
         }
     ],
     "LDLAR": [
         {
             "instr": "LDLAR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zsk1476202800525.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zsk1476202800525.htm",
             "short": "Load LOAcquire Register",
         }
     ],
     "LDLARB": [
         {
             "instr": "LDLARB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wiz1476202801135.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wiz1476202801135.htm",
             "short": "Load LOAcquire Register Byte",
         }
     ],
     "LDLARH": [
         {
             "instr": "LDLARH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_arh1476202801545.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_arh1476202801545.htm",
             "short": "Load LOAcquire Register Halfword",
         }
     ],
     "LDNP": [
         {
             "instr": "LDNP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402889.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402889.htm",
             "short": "Load Pair of Registers, with non-temporal hint",
         },
         {
             "instr": "LDNP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402499.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897402499.htm",
             "short": "Load Pair of SIMD and FP registers, with Non-temporal hint",
         },
     ],
     "LDP": [
         {
             "instr": "LDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897403789.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897403789.htm",
             "short": "Load Pair of Registers",
         },
         {
             "instr": "LDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897403349.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897403349.htm",
             "short": "Load Pair of SIMD and FP registers",
         },
     ],
     "LDPSW": [
         {
             "instr": "LDPSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897404239.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897404239.htm",
             "short": "Load Pair of Registers Signed Word",
         }
     ],
     "LDR": [
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897405180.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897405180.htm",
             "short": "Load Register (immediate)",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897406010.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897406010.htm",
             "short": "Load Register (literal)",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139540926.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139540926.htm",
             "short": "Load a register with either a 32-bit or 64-bit immediate value or any address",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897407340.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897407340.htm",
             "short": "Load Register (register)",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897404689.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897404689.htm",
             "short": "Load SIMD and FP Register (immediate offset)",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897405600.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897405600.htm",
             "short": "Load SIMD and FP Register (PC-relative literal)",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897406850.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897406850.htm",
             "short": "Load SIMD and FP Register (register offset)",
         },
     ],
     "LDRAA": [
         {
             "instr": "LDRAA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
             "short": "Load Register, with pointer authentication",
         }
     ],
     "LDRAB": [
         {
             "instr": "LDRAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
             "short": "Load Register, with pointer authentication",
         },
         {
             "instr": "LDRAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_tip1476202811729.htm",
             "short": "Load Register, with pointer authentication",
         },
     ],
     "LDRB": [
         {
             "instr": "LDRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897407820.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897407820.htm",
             "short": "Load Register Byte (immediate)",
         },
         {
             "instr": "LDRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897408350.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897408350.htm",
             "short": "Load Register Byte (register)",
         },
     ],
     "LDRH": [
         {
             "instr": "LDRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897408750.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897408750.htm",
             "short": "Load Register Halfword (immediate)",
         },
         {
             "instr": "LDRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897409240.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897409240.htm",
             "short": "Load Register Halfword (register)",
         },
     ],
     "LDRSB": [
         {
             "instr": "LDRSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897409690.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897409690.htm",
             "short": "Load Register Signed Byte (immediate)",
         },
         {
             "instr": "LDRSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897410110.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897410110.htm",
             "short": "Load Register Signed Byte (register)",
         },
     ],
     "LDRSH": [
         {
             "instr": "LDRSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897410600.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897410600.htm",
             "short": "Load Register Signed Halfword (immediate)",
         },
         {
             "instr": "LDRSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411050.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411050.htm",
             "short": "Load Register Signed Halfword (register)",
         },
     ],
     "LDRSW": [
         {
             "instr": "LDRSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411490.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411490.htm",
             "short": "Load Register Signed Word (immediate)",
         },
         {
             "instr": "LDRSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411890.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897411890.htm",
             "short": "Load Register Signed Word (literal)",
         },
         {
             "instr": "LDRSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897412350.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897412350.htm",
             "short": "Load Register Signed Word (register)",
         },
     ],
     "LDSET": [
         {
             "instr": "LDSET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
         {
             "instr": "LDSET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
     ],
     "LDSETA": [
         {
             "instr": "LDSETA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         }
     ],
     "LDSETAB": [
         {
             "instr": "LDSETAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
             "short": "Atomic bit set on byte in memory",
         }
     ],
     "LDSETAH": [
         {
             "instr": "LDSETAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
             "short": "Atomic bit set on halfword in memory",
         }
     ],
     "LDSETAL": [
         {
             "instr": "LDSETAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
         {
             "instr": "LDSETAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
     ],
     "LDSETALB": [
         {
             "instr": "LDSETALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
             "short": "Atomic bit set on byte in memory",
         }
     ],
     "LDSETALH": [
         {
             "instr": "LDSETALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
             "short": "Atomic bit set on halfword in memory",
         }
     ],
     "LDSETB": [
         {
             "instr": "LDSETB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
             "short": "Atomic bit set on byte in memory",
         }
     ],
     "LDSETH": [
         {
             "instr": "LDSETH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
             "short": "Atomic bit set on halfword in memory",
         }
     ],
     "LDSETL": [
         {
             "instr": "LDSETL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
         {
             "instr": "LDSETL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_chi1476202820379.htm",
             "short": "Atomic bit set on word or doubleword in memory",
         },
     ],
     "LDSETLB": [
         {
             "instr": "LDSETLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lay1476202820769.htm",
             "short": "Atomic bit set on byte in memory",
         }
     ],
     "LDSETLH": [
         {
             "instr": "LDSETLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xws1476202821139.htm",
             "short": "Atomic bit set on halfword in memory",
         }
     ],
     "LDSMAX": [
         {
             "instr": "LDSMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
         {
             "instr": "LDSMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
     ],
     "LDSMAXA": [
         {
             "instr": "LDSMAXA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         }
     ],
     "LDSMAXAB": [
         {
             "instr": "LDSMAXAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
             "short": "Atomic signed maximum on byte in memory",
         }
     ],
     "LDSMAXAH": [
         {
             "instr": "LDSMAXAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
             "short": "Atomic signed maximum on halfword in memory",
         }
     ],
     "LDSMAXAL": [
         {
             "instr": "LDSMAXAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
         {
             "instr": "LDSMAXAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
     ],
     "LDSMAXALB": [
         {
             "instr": "LDSMAXALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
             "short": "Atomic signed maximum on byte in memory",
         }
     ],
     "LDSMAXALH": [
         {
             "instr": "LDSMAXALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
             "short": "Atomic signed maximum on halfword in memory",
         }
     ],
     "LDSMAXB": [
         {
             "instr": "LDSMAXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
             "short": "Atomic signed maximum on byte in memory",
         }
     ],
     "LDSMAXH": [
         {
             "instr": "LDSMAXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
             "short": "Atomic signed maximum on halfword in memory",
         }
     ],
     "LDSMAXL": [
         {
             "instr": "LDSMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
         {
             "instr": "LDSMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_psk1476202821569.htm",
             "short": "Atomic signed maximum on word or doubleword in memory",
         },
     ],
     "LDSMAXLB": [
         {
             "instr": "LDSMAXLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwu1476202821929.htm",
             "short": "Atomic signed maximum on byte in memory",
         }
     ],
     "LDSMAXLH": [
         {
             "instr": "LDSMAXLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/fyt1476202822319.html",
             "short": "Atomic signed maximum on halfword in memory",
         }
     ],
     "LDSMIN": [
         {
             "instr": "LDSMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
         {
             "instr": "LDSMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
     ],
     "LDSMINA": [
         {
             "instr": "LDSMINA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         }
     ],
     "LDSMINAB": [
         {
             "instr": "LDSMINAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
             "short": "Atomic signed minimum on byte in memory",
         }
     ],
     "LDSMINAH": [
         {
             "instr": "LDSMINAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
             "short": "Atomic signed minimum on halfword in memory",
         }
     ],
     "LDSMINAL": [
         {
             "instr": "LDSMINAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
         {
             "instr": "LDSMINAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
     ],
     "LDSMINALB": [
         {
             "instr": "LDSMINALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
             "short": "Atomic signed minimum on byte in memory",
         }
     ],
     "LDSMINALH": [
         {
             "instr": "LDSMINALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
             "short": "Atomic signed minimum on halfword in memory",
         }
     ],
     "LDSMINB": [
         {
             "instr": "LDSMINB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
             "short": "Atomic signed minimum on byte in memory",
         }
     ],
     "LDSMINH": [
         {
             "instr": "LDSMINH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
             "short": "Atomic signed minimum on halfword in memory",
         }
     ],
     "LDSMINL": [
         {
             "instr": "LDSMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
         {
             "instr": "LDSMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwp1476202822709.html",
             "short": "Atomic signed minimum on word or doubleword in memory",
         },
     ],
     "LDSMINLB": [
         {
             "instr": "LDSMINLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_okf1476202823149.htm",
             "short": "Atomic signed minimum on byte in memory",
         }
     ],
     "LDSMINLH": [
         {
             "instr": "LDSMINLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zrh1476202823529.htm",
             "short": "Atomic signed minimum on halfword in memory",
         }
     ],
     "LDTR": [
         {
             "instr": "LDTR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897412740.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897412740.htm",
             "short": "Load Register (unprivileged)",
         }
     ],
     "LDTRB": [
         {
             "instr": "LDTRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897413230.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897413230.htm",
             "short": "Load Register Byte (unprivileged)",
         }
     ],
     "LDTRH": [
         {
             "instr": "LDTRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897413650.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897413650.htm",
             "short": "Load Register Halfword (unprivileged)",
         }
     ],
     "LDTRSB": [
         {
             "instr": "LDTRSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414040.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414040.htm",
             "short": "Load Register Signed Byte (unprivileged)",
         }
     ],
     "LDTRSH": [
         {
             "instr": "LDTRSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414400.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414400.htm",
             "short": "Load Register Signed Halfword (unprivileged)",
         }
     ],
     "LDTRSW": [
         {
             "instr": "LDTRSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414790.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897414790.htm",
             "short": "Load Register Signed Word (unprivileged)",
         }
     ],
     "LDUMAX": [
         {
             "instr": "LDUMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
         {
             "instr": "LDUMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
     ],
     "LDUMAXA": [
         {
             "instr": "LDUMAXA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         }
     ],
     "LDUMAXAB": [
         {
             "instr": "LDUMAXAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
             "short": "Atomic unsigned maximum on byte in memory",
         }
     ],
     "LDUMAXAH": [
         {
             "instr": "LDUMAXAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
             "short": "Atomic unsigned maximum on halfword in memory",
         }
     ],
     "LDUMAXAL": [
         {
             "instr": "LDUMAXAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
         {
             "instr": "LDUMAXAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
     ],
     "LDUMAXALB": [
         {
             "instr": "LDUMAXALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
             "short": "Atomic unsigned maximum on byte in memory",
         }
     ],
     "LDUMAXALH": [
         {
             "instr": "LDUMAXALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
             "short": "Atomic unsigned maximum on halfword in memory",
         }
     ],
     "LDUMAXB": [
         {
             "instr": "LDUMAXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
             "short": "Atomic unsigned maximum on byte in memory",
         }
     ],
     "LDUMAXH": [
         {
             "instr": "LDUMAXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
             "short": "Atomic unsigned maximum on halfword in memory",
         }
     ],
     "LDUMAXL": [
         {
             "instr": "LDUMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
         {
             "instr": "LDUMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ocv1476202828369.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory",
         },
     ],
     "LDUMAXLB": [
         {
             "instr": "LDUMAXLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/wht1476202828749.html",
             "short": "Atomic unsigned maximum on byte in memory",
         }
     ],
     "LDUMAXLH": [
         {
             "instr": "LDUMAXLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cux1476202829120.htm",
             "short": "Atomic unsigned maximum on halfword in memory",
         }
     ],
     "LDUMIN": [
         {
             "instr": "LDUMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
         {
             "instr": "LDUMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
     ],
     "LDUMINA": [
         {
             "instr": "LDUMINA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         }
     ],
     "LDUMINAB": [
         {
             "instr": "LDUMINAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
             "short": "Atomic unsigned minimum on byte in memory",
         }
     ],
     "LDUMINAH": [
         {
             "instr": "LDUMINAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
             "short": "Atomic unsigned minimum on halfword in memory",
         }
     ],
     "LDUMINAL": [
         {
             "instr": "LDUMINAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
         {
             "instr": "LDUMINAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
     ],
     "LDUMINALB": [
         {
             "instr": "LDUMINALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
             "short": "Atomic unsigned minimum on byte in memory",
         }
     ],
     "LDUMINALH": [
         {
             "instr": "LDUMINALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
             "short": "Atomic unsigned minimum on halfword in memory",
         }
     ],
     "LDUMINB": [
         {
             "instr": "LDUMINB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
             "short": "Atomic unsigned minimum on byte in memory",
         }
     ],
     "LDUMINH": [
         {
             "instr": "LDUMINH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
             "short": "Atomic unsigned minimum on halfword in memory",
         }
     ],
     "LDUMINL": [
         {
             "instr": "LDUMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
         {
             "instr": "LDUMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zmq1476202829590.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory",
         },
     ],
     "LDUMINLB": [
         {
             "instr": "LDUMINLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fsr1476202829960.htm",
             "short": "Atomic unsigned minimum on byte in memory",
         }
     ],
     "LDUMINLH": [
         {
             "instr": "LDUMINLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_uzo1476202830320.htm",
             "short": "Atomic unsigned minimum on halfword in memory",
         }
     ],
     "LDUR": [
         {
             "instr": "LDUR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897415610.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897415610.htm",
             "short": "Load Register (unscaled)",
         },
         {
             "instr": "LDUR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897415180.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897415180.htm",
             "short": "Load SIMD and FP Register (unscaled offset)",
         },
     ],
     "LDURB": [
         {
             "instr": "LDURB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416000.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416000.htm",
             "short": "Load Register Byte (unscaled)",
         }
     ],
     "LDURH": [
         {
             "instr": "LDURH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416410.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416410.htm",
             "short": "Load Register Halfword (unscaled)",
         }
     ],
     "LDURSB": [
         {
             "instr": "LDURSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416810.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897416810.htm",
             "short": "Load Register Signed Byte (unscaled)",
         }
     ],
     "LDURSH": [
         {
             "instr": "LDURSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417210.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417210.htm",
             "short": "Load Register Signed Halfword (unscaled)",
         }
     ],
     "LDURSW": [
         {
             "instr": "LDURSW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417590.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417590.htm",
             "short": "Load Register Signed Word (unscaled)",
         }
     ],
     "LDXP": [
         {
             "instr": "LDXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417980.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897417980.htm",
             "short": "Load Exclusive Pair of Registers",
         }
     ],
     "LDXR": [
         {
             "instr": "LDXR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897418390.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897418390.htm",
             "short": "Load Exclusive Register",
         }
     ],
     "LDXRB": [
         {
             "instr": "LDXRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897418780.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897418780.htm",
             "short": "Load Exclusive Register Byte",
         }
     ],
     "LDXRH": [
         {
             "instr": "LDXRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897419230.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897419230.htm",
             "short": "Load Exclusive Register Halfword",
         }
     ],
     "LSL": [
         {
             "instr": "LSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674946.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897674946.htm",
             "short": "Logical Shift Left (register)",
         },
         {
             "instr": "LSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897675486.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897675486.htm",
             "short": "Logical Shift Left (immediate)",
         },
     ],
     "LSLV": [
         {
             "instr": "LSLV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897676066.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897676066.htm",
             "short": "Logical Shift Left Variable",
         }
     ],
     "LSR": [
         {
             "instr": "LSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897676576.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897676576.htm",
             "short": "Logical Shift Right (register)",
         },
         {
             "instr": "LSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897677176.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897677176.htm",
             "short": "Logical Shift Right (immediate)",
         },
     ],
     "LSRV": [
         {
             "instr": "LSRV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897677706.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897677706.htm",
             "short": "Logical Shift Right Variable",
         }
     ],
     "MADD": [
         {
             "instr": "MADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897678206.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897678206.htm",
             "short": "Multiply-Add",
         }
     ],
     "MLA": [
         {
             "instr": "MLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897535707.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897535707.htm",
             "short": "Multiply-Add to accumulator (vector, by element)",
         },
         {
             "instr": "MLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897536137.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897536137.htm",
             "short": "Multiply-Add to accumulator (vector)",
         },
     ],
     "MLS": [
         {
             "instr": "MLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897536557.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897536557.htm",
             "short": "Multiply-Subtract from accumulator (vector, by element)",
         },
         {
             "instr": "MLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537027.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537027.htm",
             "short": "Multiply-Subtract from accumulator (vector)",
         },
     ],
     "MNEG": [
         {
             "instr": "MNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897678746.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897678746.htm",
             "short": "Multiply-Negate",
         }
     ],
     "MOV": [
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897679276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897679276.htm",
             "short": "Move between register and stack pointer",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897679756.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897679756.htm",
             "short": "Move (inverted wide immediate)",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897680286.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897680286.htm",
             "short": "Move (wide immediate)",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897680846.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897680846.htm",
             "short": "Move (bitmask immediate)",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897681296.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897681296.htm",
             "short": "Move (register)",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462083.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462083.htm",
             "short": "Move vector element to scalar",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537427.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537427.htm",
             "short": "Move vector element to another vector element",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537847.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897537847.htm",
             "short": "Move general-purpose register to a vector element",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897538238.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897538238.htm",
             "short": "Move vector",
         },
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897538628.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897538628.htm",
             "short": "Move vector element to general-purpose register",
         },
     ],
     "MOVI": [
         {
             "instr": "MOVI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539038.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539038.htm",
             "short": "Move Immediate (vector)",
         }
     ],
     "MOVK": [
         {
             "instr": "MOVK",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897681726.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897681726.htm",
             "short": "Move wide with keep",
         }
     ],
     "MOVL": [
         {
             "instr": "MOVL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139319561.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1395139319561.htm",
             "short": "Load a register with either a 32-bit or 64-bit immediate value or any address",
         }
     ],
     "MOVN": [
         {
             "instr": "MOVN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897682626.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897682626.htm",
             "short": "Move wide with NOT",
         }
     ],
     "MOVZ": [
         {
             "instr": "MOVZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897683016.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897683016.htm",
             "short": "Move wide with zero",
         }
     ],
     "MRS": [
         {
             "instr": "MRS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897683416.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897683416.htm",
             "short": "Move System Register",
         }
     ],
     "MSR": [
         {
             "instr": "MSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897684376.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897684376.htm",
             "short": "Move immediate value to Special Register",
         },
         {
             "instr": "MSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897684806.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897684806.htm",
             "short": "Move general-purpose register to System Register",
         },
     ],
     "MSUB": [
         {
             "instr": "MSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897685216.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897685216.htm",
             "short": "Multiply-Subtract",
         }
     ],
     "MUL": [
         {
             "instr": "MUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897685656.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897685656.htm",
             "short": "Multiply",
         },
         {
             "instr": "MUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539498.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539498.htm",
             "short": "Multiply (vector, by element)",
         },
         {
             "instr": "MUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539898.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897539898.htm",
             "short": "Multiply (vector)",
         },
     ],
     "MVN": [
         {
             "instr": "MVN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686066.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686066.htm",
             "short": "Bitwise NOT",
         },
         {
             "instr": "MVN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897540328.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897540328.htm",
             "short": "Bitwise NOT (vector)",
         },
     ],
     "MVNI": [
         {
             "instr": "MVNI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897540708.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897540708.htm",
             "short": "Move inverted Immediate (vector)",
         }
     ],
     "NEG": [
         {
             "instr": "NEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686476.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686476.htm",
             "short": "Negate (shifted register)",
         },
         {
             "instr": "NEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462463.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462463.htm",
             "short": "Negate (vector)",
         },
         {
             "instr": "NEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897541198.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897541198.htm",
             "short": "Negate (vector)",
         },
     ],
     "NEGS": [
         {
             "instr": "NEGS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686926.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897686926.htm",
             "short": "Negate, setting flags",
         }
     ],
     "NGC": [
         {
             "instr": "NGC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897687346.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897687346.htm",
             "short": "Negate with Carry",
         }
     ],
     "NGCS": [
         {
             "instr": "NGCS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897687876.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897687876.htm",
             "short": "Negate with Carry, setting flags",
         }
     ],
     "NOP": [
         {
             "instr": "NOP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fxn1476202741801.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fxn1476202741801.htm",
             "short": "No Operation",
         }
     ],
     "NOT": [
         {
             "instr": "NOT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897541688.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897541688.htm",
             "short": "Bitwise NOT (vector)",
         }
     ],
     "ORN": [
         {
             "instr": "ORN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897688871.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897688871.htm",
             "short": "Bitwise OR NOT (shifted register)",
         },
         {
             "instr": "ORN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897542168.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897542168.htm",
             "short": "Bitwise inclusive OR NOT (vector)",
         },
     ],
     "ORR": [
         {
             "instr": "ORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897689351.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897689351.htm",
             "short": "Bitwise OR (immediate)",
         },
         {
             "instr": "ORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897689792.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897689792.htm",
             "short": "Bitwise OR (shifted register)",
         },
         {
             "instr": "ORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897542838.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897542838.htm",
             "short": "Bitwise inclusive OR (vector, immediate)",
         },
         {
             "instr": "ORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897543308.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897543308.htm",
             "short": "Bitwise inclusive OR (vector, register)",
         },
     ],
     "PACDA": [
         {
             "instr": "PACDA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mlg1476202744441.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mlg1476202744441.htm",
             "short": "Pointer Authentication Code for Data address, using key A",
         }
     ],
     "PACDB": [
         {
             "instr": "PACDB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ggo1476202744811.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ggo1476202744811.htm",
             "short": "Pointer Authentication Code for Data address, using key B",
         }
     ],
     "PACDZA": [
         {
             "instr": "PACDZA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mlg1476202744441.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mlg1476202744441.htm",
             "short": "Pointer Authentication Code for Data address, using key A",
         }
     ],
     "PACDZB": [
         {
             "instr": "PACDZB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ggo1476202744811.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ggo1476202744811.htm",
             "short": "Pointer Authentication Code for Data address, using key B",
         }
     ],
     "PACGA": [
         {
             "instr": "PACGA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fbm1476202745161.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fbm1476202745161.htm",
             "short": "Pointer Authentication Code, using Generic key",
         }
     ],
     "PACIA": [
         {
             "instr": "PACIA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
             "short": "Pointer Authentication Code for Instruction address, using key A",
         }
     ],
     "PACIA1716": [
         {
             "instr": "PACIA1716",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
             "short": "Pointer Authentication Code for Instruction address, using key A",
         }
     ],
     "PACIASP": [
         {
             "instr": "PACIASP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
             "short": "Pointer Authentication Code for Instruction address, using key A",
         }
     ],
     "PACIAZ": [
         {
             "instr": "PACIAZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
             "short": "Pointer Authentication Code for Instruction address, using key A",
         }
     ],
     "PACIB": [
         {
             "instr": "PACIB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
             "short": "Pointer Authentication Code for Instruction address, using key B",
         }
     ],
     "PACIB1716": [
         {
             "instr": "PACIB1716",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
             "short": "Pointer Authentication Code for Instruction address, using key B",
         }
     ],
     "PACIBSP": [
         {
             "instr": "PACIBSP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
             "short": "Pointer Authentication Code for Instruction address, using key B",
         }
     ],
     "PACIBZ": [
         {
             "instr": "PACIBZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
             "short": "Pointer Authentication Code for Instruction address, using key B",
         }
     ],
     "PACIZA": [
         {
             "instr": "PACIZA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vco1476202745841.htm",
             "short": "Pointer Authentication Code for Instruction address, using key A",
         }
     ],
     "PACIZB": [
         {
             "instr": "PACIZB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mpg1476202746202.htm",
             "short": "Pointer Authentication Code for Instruction address, using key B",
         }
     ],
     "PMUL": [
         {
             "instr": "PMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897543848.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897543848.htm",
             "short": "Polynomial Multiply",
         }
     ],
     "PMULL": [
         {
             "instr": "PMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544358.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544358.htm",
             "short": "Polynomial Multiply Long",
         }
     ],
     "PMULL2": [
         {
             "instr": "PMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544358.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544358.htm",
             "short": "Polynomial Multiply Long",
         }
     ],
     "PRFM": [
         {
             "instr": "PRFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897419630.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897419630.htm",
             "short": "Prefetch Memory (immediate)",
         },
         {
             "instr": "PRFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897420050.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897420050.htm",
             "short": "Prefetch Memory (literal)",
         },
         {
             "instr": "PRFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897420470.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897420470.htm",
             "short": "Prefetch Memory (register)",
         },
     ],
     "PRFUM": [
         {
             "instr": "PRFUM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897421040.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897421040.htm",
             "short": "Prefetch Memory (unscaled offset)",
         }
     ],
     "PSB": [
         {
             "instr": "PSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_eeb1476202746582.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_eeb1476202746582.htm",
             "short": "Profiling Synchronization Barrier",
         }
     ],
     "RADDHN": [
         {
             "instr": "RADDHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544908.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544908.htm",
             "short": "Rounding Add returning High Narrow",
         }
     ],
     "RADDHN2": [
         {
             "instr": "RADDHN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544908.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897544908.htm",
             "short": "Rounding Add returning High Narrow",
         }
     ],
     "RBIT": [
         {
             "instr": "RBIT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897690295.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897690295.htm",
             "short": "Reverse Bits",
         },
         {
             "instr": "RBIT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897545478.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897545478.htm",
             "short": "Reverse Bit order (vector)",
         },
     ],
     "RET": [
         {
             "instr": "RET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897690725.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897690725.htm",
             "short": "Return from subroutine",
         }
     ],
     "RETAA": [
         {
             "instr": "RETAA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_osg1476202748462.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_osg1476202748462.htm",
             "short": "Return from subroutine, with pointer authentication",
         }
     ],
     "RETAB": [
         {
             "instr": "RETAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_osg1476202748462.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_osg1476202748462.htm",
             "short": "Return from subroutine, with pointer authentication",
         }
     ],
     "REV": [
         {
             "instr": "REV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691975.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691975.htm",
             "short": "Reverse Bytes",
         }
     ],
     "REV16": [
         {
             "instr": "REV16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691135.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691135.htm",
             "short": "Reverse bytes in 16-bit halfwords",
         },
         {
             "instr": "REV16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897546018.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897546018.htm",
             "short": "Reverse elements in 16-bit halfwords (vector)",
         },
     ],
     "REV32": [
         {
             "instr": "REV32",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691555.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897691555.htm",
             "short": "Reverse bytes in 32-bit words",
         },
         {
             "instr": "REV32",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897546518.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897546518.htm",
             "short": "Reverse elements in 32-bit words (vector)",
         },
     ],
     "REV64": [
         {
             "instr": "REV64",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lyc1476202750282.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_lyc1476202750282.htm",
             "short": "Reverse Bytes",
         },
         {
             "instr": "REV64",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547018.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547018.htm",
             "short": "Reverse elements in 64-bit doublewords (vector)",
         },
     ],
     "ROR": [
         {
             "instr": "ROR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897695545.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897695545.htm",
             "short": "Rotate right (immediate)",
         },
         {
             "instr": "ROR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897695925.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897695925.htm",
             "short": "Rotate Right (register)",
         },
     ],
     "RORV": [
         {
             "instr": "RORV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897696405.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897696405.htm",
             "short": "Rotate Right Variable",
         }
     ],
     "RSHRN": [
         {
             "instr": "RSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547428.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547428.htm",
             "short": "Rounding Shift Right Narrow (immediate)",
         }
     ],
     "RSHRN2": [
         {
             "instr": "RSHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547428.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547428.htm",
             "short": "Rounding Shift Right Narrow (immediate)",
         }
     ],
     "RSUBHN": [
         {
             "instr": "RSUBHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547868.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547868.htm",
             "short": "Rounding Subtract returning High Narrow",
         }
     ],
     "RSUBHN2": [
         {
             "instr": "RSUBHN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547868.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897547868.htm",
             "short": "Rounding Subtract returning High Narrow",
         }
     ],
     "SABA": [
         {
             "instr": "SABA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548348.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548348.htm",
             "short": "Signed Absolute difference and Accumulate",
         }
     ],
     "SABAL": [
         {
             "instr": "SABAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548828.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548828.htm",
             "short": "Signed Absolute difference and Accumulate Long",
         }
     ],
     "SABAL2": [
         {
             "instr": "SABAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548828.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897548828.htm",
             "short": "Signed Absolute difference and Accumulate Long",
         }
     ],
     "SABD": [
         {
             "instr": "SABD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549328.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549328.htm",
             "short": "Signed Absolute Difference",
         }
     ],
     "SABDL": [
         {
             "instr": "SABDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549818.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549818.htm",
             "short": "Signed Absolute Difference Long",
         }
     ],
     "SABDL2": [
         {
             "instr": "SABDL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549818.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897549818.htm",
             "short": "Signed Absolute Difference Long",
         }
     ],
     "SADALP": [
         {
             "instr": "SADALP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550298.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550298.htm",
             "short": "Signed Add and Accumulate Long Pairwise",
         }
     ],
     "SADDL": [
         {
             "instr": "SADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550868.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550868.htm",
             "short": "Signed Add Long (vector)",
         }
     ],
     "SADDL2": [
         {
             "instr": "SADDL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550868.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897550868.htm",
             "short": "Signed Add Long (vector)",
         }
     ],
     "SADDLP": [
         {
             "instr": "SADDLP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897551398.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897551398.htm",
             "short": "Signed Add Long Pairwise",
         }
     ],
     "SADDLV": [
         {
             "instr": "SADDLV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897551988.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897551988.htm",
             "short": "Signed Add Long across Vector",
         }
     ],
     "SADDW": [
         {
             "instr": "SADDW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897552518.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897552518.htm",
             "short": "Signed Add Wide",
         }
     ],
     "SADDW2": [
         {
             "instr": "SADDW2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897552518.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897552518.htm",
             "short": "Signed Add Wide",
         }
     ],
     "SBC": [
         {
             "instr": "SBC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897696825.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897696825.htm",
             "short": "Subtract with Carry",
         }
     ],
     "SBCS": [
         {
             "instr": "SBCS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897701701.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897701701.htm",
             "short": "Subtract with Carry, setting flags",
         }
     ],
     "SBFIZ": [
         {
             "instr": "SBFIZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897703689.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897703689.htm",
             "short": "Signed Bitfield Insert in Zero",
         }
     ],
     "SBFM": [
         {
             "instr": "SBFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704099.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704099.htm",
             "short": "Signed Bitfield Move",
         }
     ],
     "SBFX": [
         {
             "instr": "SBFX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704549.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704549.htm",
             "short": "Signed Bitfield Extract",
         }
     ],
     "SCVTF": [
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897636223.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897636223.htm",
             "short": "Signed fixed-point Convert to Floating-point (scalar)",
         },
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897636663.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897636663.htm",
             "short": "Signed integer Convert to Floating-point (scalar)",
         },
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462833.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897462833.htm",
             "short": "Signed fixed-point Convert to Floating-point (vector)",
         },
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463243.htm",
             "short": "Signed integer Convert to Floating-point (vector)",
         },
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897553058.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897553058.htm",
             "short": "Signed fixed-point Convert to Floating-point (vector)",
         },
         {
             "instr": "SCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897553558.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897553558.htm",
             "short": "Signed integer Convert to Floating-point (vector)",
         },
     ],
     "SDIV": [
         {
             "instr": "SDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704989.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897704989.htm",
             "short": "Signed Divide",
         }
     ],
     "SEV": [
         {
             "instr": "SEV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fdo1476202758732.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fdo1476202758732.htm",
             "short": "Send Event",
         }
     ],
     "SEVL": [
         {
             "instr": "SEVL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ios1476202759102.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ios1476202759102.htm",
             "short": "Send Event Local",
         }
     ],
     "SHADD": [
         {
             "instr": "SHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554008.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554008.htm",
             "short": "Signed Halving Add",
         }
     ],
     "SHL": [
         {
             "instr": "SHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463603.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463603.htm",
             "short": "Shift Left (immediate)",
         },
         {
             "instr": "SHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554428.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554428.htm",
             "short": "Shift Left (immediate)",
         },
     ],
     "SHLL": [
         {
             "instr": "SHLL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554959.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554959.htm",
             "short": "Shift Left Long (by element size)",
         }
     ],
     "SHLL2": [
         {
             "instr": "SHLL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554959.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897554959.htm",
             "short": "Shift Left Long (by element size)",
         }
     ],
     "SHRN": [
         {
             "instr": "SHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555479.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555479.htm",
             "short": "Shift Right Narrow (immediate)",
         }
     ],
     "SHRN2": [
         {
             "instr": "SHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555479.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555479.htm",
             "short": "Shift Right Narrow (immediate)",
         }
     ],
     "SHSUB": [
         {
             "instr": "SHSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555959.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897555959.htm",
             "short": "Signed Halving Subtract",
         }
     ],
     "SLI": [
         {
             "instr": "SLI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463983.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897463983.htm",
             "short": "Shift Left and Insert (immediate)",
         },
         {
             "instr": "SLI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897556429.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897556429.htm",
             "short": "Shift Left and Insert (immediate)",
         },
     ],
     "SMADDL": [
         {
             "instr": "SMADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897706779.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897706779.htm",
             "short": "Signed Multiply-Add Long",
         }
     ],
     "SMAX": [
         {
             "instr": "SMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897556919.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897556919.htm",
             "short": "Signed Maximum (vector)",
         }
     ],
     "SMAXP": [
         {
             "instr": "SMAXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897557419.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897557419.htm",
             "short": "Signed Maximum Pairwise",
         }
     ],
     "SMAXV": [
         {
             "instr": "SMAXV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897557909.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897557909.htm",
             "short": "Signed Maximum across Vector",
         }
     ],
     "SMC": [
         {
             "instr": "SMC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897707179.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897707179.htm",
             "short": "Supervisor call to allow OS or Hypervisor code to call the Secure Monitor",
         }
     ],
     "SMIN": [
         {
             "instr": "SMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897558439.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897558439.htm",
             "short": "Signed Minimum (vector)",
         }
     ],
     "SMINP": [
         {
             "instr": "SMINP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897558939.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897558939.htm",
             "short": "Signed Minimum Pairwise",
         }
     ],
     "SMINV": [
         {
             "instr": "SMINV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897559509.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897559509.htm",
             "short": "Signed Minimum across Vector",
         }
     ],
     "SMLAL": [
         {
             "instr": "SMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560049.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560049.htm",
             "short": "Signed Multiply-Add Long (vector, by element)",
         },
         {
             "instr": "SMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560629.htm",
             "short": "Signed Multiply-Add Long (vector)",
         },
     ],
     "SMLAL2": [
         {
             "instr": "SMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560049.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560049.htm",
             "short": "Signed Multiply-Add Long (vector, by element)",
         },
         {
             "instr": "SMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897560629.htm",
             "short": "Signed Multiply-Add Long (vector)",
         },
     ],
     "SMLSL": [
         {
             "instr": "SMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561089.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561089.htm",
             "short": "Signed Multiply-Subtract Long (vector, by element)",
         },
         {
             "instr": "SMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561559.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561559.htm",
             "short": "Signed Multiply-Subtract Long (vector)",
         },
     ],
     "SMLSL2": [
         {
             "instr": "SMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561089.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561089.htm",
             "short": "Signed Multiply-Subtract Long (vector, by element)",
         },
         {
             "instr": "SMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561559.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897561559.htm",
             "short": "Signed Multiply-Subtract Long (vector)",
         },
     ],
     "SMNEGL": [
         {
             "instr": "SMNEGL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897707739.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897707739.htm",
             "short": "Signed Multiply-Negate Long",
         }
     ],
     "SMOV": [
         {
             "instr": "SMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562019.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562019.htm",
             "short": "Signed Move vector element to general-purpose register",
         }
     ],
     "SMSUBL": [
         {
             "instr": "SMSUBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708159.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708159.htm",
             "short": "Signed Multiply-Subtract Long",
         }
     ],
     "SMULH": [
         {
             "instr": "SMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708539.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708539.htm",
             "short": "Signed Multiply High",
         }
     ],
     "SMULL": [
         {
             "instr": "SMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708949.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897708949.htm",
             "short": "Signed Multiply Long",
         },
         {
             "instr": "SMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562449.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562449.htm",
             "short": "Signed Multiply Long (vector, by element)",
         },
         {
             "instr": "SMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562919.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562919.htm",
             "short": "Signed Multiply Long (vector)",
         },
     ],
     "SMULL2": [
         {
             "instr": "SMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562449.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562449.htm",
             "short": "Signed Multiply Long (vector, by element)",
         },
         {
             "instr": "SMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562919.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897562919.htm",
             "short": "Signed Multiply Long (vector)",
         },
     ],
     "SQABS": [
         {
             "instr": "SQABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897464403.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897464403.htm",
             "short": "Signed saturating Absolute value",
         },
         {
             "instr": "SQABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897563339.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897563339.htm",
             "short": "Signed saturating Absolute value",
         },
     ],
     "SQADD": [
         {
             "instr": "SQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897464823.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897464823.htm",
             "short": "Signed saturating Add",
         },
         {
             "instr": "SQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897563729.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897563729.htm",
             "short": "Signed saturating Add",
         },
     ],
     "SQDMLAL": [
         {
             "instr": "SQDMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897465243.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897465243.htm",
             "short": "Signed saturating Doubling Multiply-Add Long (by element)",
         },
         {
             "instr": "SQDMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897465673.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897465673.htm",
             "short": "Signed saturating Doubling Multiply-Add Long",
         },
         {
             "instr": "SQDMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564119.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564119.htm",
             "short": "Signed saturating Doubling Multiply-Add Long (by element)",
         },
         {
             "instr": "SQDMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564559.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564559.htm",
             "short": "Signed saturating Doubling Multiply-Add Long",
         },
     ],
     "SQDMLAL2": [
         {
             "instr": "SQDMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564119.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564119.htm",
             "short": "Signed saturating Doubling Multiply-Add Long (by element)",
         },
         {
             "instr": "SQDMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564559.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564559.htm",
             "short": "Signed saturating Doubling Multiply-Add Long",
         },
     ],
     "SQDMLSL": [
         {
             "instr": "SQDMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466093.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466093.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long (by element)",
         },
         {
             "instr": "SQDMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466523.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466523.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long",
         },
         {
             "instr": "SQDMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564989.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564989.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long (by element)",
         },
         {
             "instr": "SQDMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565379.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long",
         },
     ],
     "SQDMLSL2": [
         {
             "instr": "SQDMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564989.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897564989.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long (by element)",
         },
         {
             "instr": "SQDMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565379.htm",
             "short": "Signed saturating Doubling Multiply-Subtract Long",
         },
     ],
     "SQDMULH": [
         {
             "instr": "SQDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466923.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897466923.htm",
             "short": "Signed saturating Doubling Multiply returning High half (by element)",
         },
         {
             "instr": "SQDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897467373.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897467373.htm",
             "short": "Signed saturating Doubling Multiply returning High half",
         },
         {
             "instr": "SQDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565779.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897565779.htm",
             "short": "Signed saturating Doubling Multiply returning High half (by element)",
         },
         {
             "instr": "SQDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566209.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566209.htm",
             "short": "Signed saturating Doubling Multiply returning High half",
         },
     ],
     "SQDMULL": [
         {
             "instr": "SQDMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897467783.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897467783.htm",
             "short": "Signed saturating Doubling Multiply Long (by element)",
         },
         {
             "instr": "SQDMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897468233.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897468233.htm",
             "short": "Signed saturating Doubling Multiply Long",
         },
         {
             "instr": "SQDMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566609.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566609.htm",
             "short": "Signed saturating Doubling Multiply Long (by element)",
         },
         {
             "instr": "SQDMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567029.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567029.htm",
             "short": "Signed saturating Doubling Multiply Long",
         },
     ],
     "SQDMULL2": [
         {
             "instr": "SQDMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566609.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897566609.htm",
             "short": "Signed saturating Doubling Multiply Long (by element)",
         },
         {
             "instr": "SQDMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567029.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567029.htm",
             "short": "Signed saturating Doubling Multiply Long",
         },
     ],
     "SQNEG": [
         {
             "instr": "SQNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897468643.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897468643.htm",
             "short": "Signed saturating Negate",
         },
         {
             "instr": "SQNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567419.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567419.htm",
             "short": "Signed saturating Negate",
         },
     ],
     "SQRDMLAH": [
         {
             "instr": "SQRDMLAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ajc1476202980371.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ajc1476202980371.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Accumulate returning High Half (by element)",
         },
         {
             "instr": "SQRDMLAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jrd1476202980801.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jrd1476202980801.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Accumulate returning High Half (vector)",
         },
         {
             "instr": "SQRDMLAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ajk1476203155444.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ajk1476203155444.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Accumulate returning High Half (by element)",
         },
         {
             "instr": "SQRDMLAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fob1476203155834.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fob1476203155834.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Accumulate returning High Half (vector)",
         },
     ],
     "SQRDMLSH": [
         {
             "instr": "SQRDMLSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_puu1476202981191.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_puu1476202981191.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Subtract returning High Half (by element)",
         },
         {
             "instr": "SQRDMLSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hvp1476202981571.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hvp1476202981571.html",
             "short": "Signed Saturating Rounding Doubling Multiply Subtract returning High Half (vector)",
         },
         {
             "instr": "SQRDMLSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_awz1476203156194.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_awz1476203156194.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Subtract returning High Half (by element)",
         },
         {
             "instr": "SQRDMLSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xza1476203156554.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xza1476203156554.htm",
             "short": "Signed Saturating Rounding Doubling Multiply Subtract returning High Half (vector)",
         },
     ],
     "SQRDMULH": [
         {
             "instr": "SQRDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469073.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469073.htm",
             "short": "Signed saturating Rounding Doubling Multiply returning High half (by element)",
         },
         {
             "instr": "SQRDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469503.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469503.htm",
             "short": "Signed saturating Rounding Doubling Multiply returning High half",
         },
         {
             "instr": "SQRDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567829.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897567829.htm",
             "short": "Signed saturating Rounding Doubling Multiply returning High half (by element)",
         },
         {
             "instr": "SQRDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897568249.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897568249.htm",
             "short": "Signed saturating Rounding Doubling Multiply returning High half",
         },
     ],
     "SQRSHL": [
         {
             "instr": "SQRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469933.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897469933.htm",
             "short": "Signed saturating Rounding Shift Left (register)",
         },
         {
             "instr": "SQRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897568649.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897568649.htm",
             "short": "Signed saturating Rounding Shift Left (register)",
         },
     ],
     "SQRSHRN": [
         {
             "instr": "SQRSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897470343.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897470343.htm",
             "short": "Signed saturating Rounded Shift Right Narrow (immediate)",
         },
         {
             "instr": "SQRSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569039.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569039.htm",
             "short": "Signed saturating Rounded Shift Right Narrow (immediate)",
         },
     ],
     "SQRSHRN2": [
         {
             "instr": "SQRSHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569039.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569039.htm",
             "short": "Signed saturating Rounded Shift Right Narrow (immediate)",
         }
     ],
     "SQRSHRUN": [
         {
             "instr": "SQRSHRUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897470763.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897470763.htm",
             "short": "Signed saturating Rounded Shift Right Unsigned Narrow (immediate)",
         },
         {
             "instr": "SQRSHRUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569479.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569479.htm",
             "short": "Signed saturating Rounded Shift Right Unsigned Narrow (immediate)",
         },
     ],
     "SQRSHRUN2": [
         {
             "instr": "SQRSHRUN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569479.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569479.htm",
             "short": "Signed saturating Rounded Shift Right Unsigned Narrow (immediate)",
         }
     ],
     "SQSHL": [
         {
             "instr": "SQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471203.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471203.htm",
             "short": "Signed saturating Shift Left (immediate)",
         },
         {
             "instr": "SQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471604.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471604.htm",
             "short": "Signed saturating Shift Left (register)",
         },
         {
             "instr": "SQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569889.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897569889.htm",
             "short": "Signed saturating Shift Left (immediate)",
         },
         {
             "instr": "SQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897570319.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897570319.htm",
             "short": "Signed saturating Shift Left (register)",
         },
     ],
     "SQSHLU": [
         {
             "instr": "SQSHLU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471994.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897471994.htm",
             "short": "Signed saturating Shift Left Unsigned (immediate)",
         },
         {
             "instr": "SQSHLU",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897570709.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897570709.htm",
             "short": "Signed saturating Shift Left Unsigned (immediate)",
         },
     ],
     "SQSHRN": [
         {
             "instr": "SQSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897472374.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897472374.htm",
             "short": "Signed saturating Shift Right Narrow (immediate)",
         },
         {
             "instr": "SQSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571189.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571189.htm",
             "short": "Signed saturating Shift Right Narrow (immediate)",
         },
     ],
     "SQSHRN2": [
         {
             "instr": "SQSHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571189.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571189.htm",
             "short": "Signed saturating Shift Right Narrow (immediate)",
         }
     ],
     "SQSHRUN": [
         {
             "instr": "SQSHRUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897472784.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897472784.htm",
             "short": "Signed saturating Shift Right Unsigned Narrow (immediate)",
         },
         {
             "instr": "SQSHRUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571610.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571610.htm",
             "short": "Signed saturating Shift Right Unsigned Narrow (immediate)",
         },
     ],
     "SQSHRUN2": [
         {
             "instr": "SQSHRUN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571610.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897571610.htm",
             "short": "Signed saturating Shift Right Unsigned Narrow (immediate)",
         }
     ],
     "SQSUB": [
         {
             "instr": "SQSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897473214.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897473214.htm",
             "short": "Signed saturating Subtract",
         },
         {
             "instr": "SQSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572090.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572090.htm",
             "short": "Signed saturating Subtract",
         },
     ],
     "SQXTN": [
         {
             "instr": "SQXTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897473614.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897473614.htm",
             "short": "Signed saturating extract Narrow",
         },
         {
             "instr": "SQXTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572460.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572460.htm",
             "short": "Signed saturating extract Narrow",
         },
     ],
     "SQXTN2": [
         {
             "instr": "SQXTN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572460.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572460.htm",
             "short": "Signed saturating extract Narrow",
         }
     ],
     "SQXTUN": [
         {
             "instr": "SQXTUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474024.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474024.htm",
             "short": "Signed saturating extract Unsigned Narrow",
         },
         {
             "instr": "SQXTUN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572850.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572850.htm",
             "short": "Signed saturating extract Unsigned Narrow",
         },
     ],
     "SQXTUN2": [
         {
             "instr": "SQXTUN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572850.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897572850.htm",
             "short": "Signed saturating extract Unsigned Narrow",
         }
     ],
     "SRHADD": [
         {
             "instr": "SRHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897573250.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897573250.htm",
             "short": "Signed Rounding Halving Add",
         }
     ],
     "SRI": [
         {
             "instr": "SRI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474424.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474424.htm",
             "short": "Shift Right and Insert (immediate)",
         },
         {
             "instr": "SRI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897573640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897573640.htm",
             "short": "Shift Right and Insert (immediate)",
         },
     ],
     "SRSHL": [
         {
             "instr": "SRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474804.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897474804.htm",
             "short": "Signed Rounding Shift Left (register)",
         },
         {
             "instr": "SRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574040.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574040.htm",
             "short": "Signed Rounding Shift Left (register)",
         },
     ],
     "SRSHR": [
         {
             "instr": "SRSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897475214.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897475214.htm",
             "short": "Signed Rounding Shift Right (immediate)",
         },
         {
             "instr": "SRSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574510.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574510.htm",
             "short": "Signed Rounding Shift Right (immediate)",
         },
     ],
     "SRSRA": [
         {
             "instr": "SRSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897475634.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897475634.htm",
             "short": "Signed Rounding Shift Right and Accumulate (immediate)",
         },
         {
             "instr": "SRSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574900.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897574900.htm",
             "short": "Signed Rounding Shift Right and Accumulate (immediate)",
         },
     ],
     "SSHL": [
         {
             "instr": "SSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476044.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476044.htm",
             "short": "Signed Shift Left (register)",
         },
         {
             "instr": "SSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575330.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575330.htm",
             "short": "Signed Shift Left (register)",
         },
     ],
     "SSHLL": [
         {
             "instr": "SSHLL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575700.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575700.htm",
             "short": "Signed Shift Left Long (immediate)",
         }
     ],
     "SSHLL2": [
         {
             "instr": "SSHLL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575700.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897575700.htm",
             "short": "Signed Shift Left Long (immediate)",
         }
     ],
     "SSHR": [
         {
             "instr": "SSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476444.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476444.htm",
             "short": "Signed Shift Right (immediate)",
         },
         {
             "instr": "SSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576160.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576160.htm",
             "short": "Signed Shift Right (immediate)",
         },
     ],
     "SSRA": [
         {
             "instr": "SSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476834.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897476834.htm",
             "short": "Signed Shift Right and Accumulate (immediate)",
         },
         {
             "instr": "SSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576560.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576560.htm",
             "short": "Signed Shift Right and Accumulate (immediate)",
         },
     ],
     "SSUBL": [
         {
             "instr": "SSUBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576960.htm",
             "short": "Signed Subtract Long",
         }
     ],
     "SSUBL2": [
         {
             "instr": "SSUBL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576960.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897576960.htm",
             "short": "Signed Subtract Long",
         }
     ],
     "SSUBW": [
         {
             "instr": "SSUBW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577420.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577420.htm",
             "short": "Signed Subtract Wide",
         }
     ],
     "SSUBW2": [
         {
             "instr": "SSUBW2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577420.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577420.htm",
             "short": "Signed Subtract Wide",
         }
     ],
     "ST1": [
         {
             "instr": "ST1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897577870.htm",
             "short": "Store multiple single-element structures from one, two, three, or four registers",
         },
         {
             "instr": "ST1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897578510.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897578510.htm",
             "short": "Store a single-element structure from one lane of one register",
         },
     ],
     "ST2": [
         {
             "instr": "ST2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897578940.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897578940.htm",
             "short": "Store multiple 2-element structures from two registers",
         },
         {
             "instr": "ST2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897579390.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897579390.htm",
             "short": "Store single 2-element structure from one lane of two registers",
         },
     ],
     "ST3": [
         {
             "instr": "ST3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897579820.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897579820.htm",
             "short": "Store multiple 3-element structures from three registers",
         },
         {
             "instr": "ST3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897580910.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897580910.htm",
             "short": "Store single 3-element structure from one lane of three registers",
         },
     ],
     "ST4": [
         {
             "instr": "ST4",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897581360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897581360.htm",
             "short": "Store multiple 4-element structures from four registers",
         },
         {
             "instr": "ST4",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897581780.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897581780.htm",
             "short": "Store single 4-element structure from one lane of four registers",
         },
     ],
     "STADD": [
         {
             "instr": "STADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
             "short": "Atomic add on word or doubleword in memory, without return",
         }
     ],
     "STADDB": [
         {
             "instr": "STADDB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwj1476202845050.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwj1476202845050.html",
             "short": "Atomic add on byte in memory, without return",
         }
     ],
     "STADDH": [
         {
             "instr": "STADDH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nju1476202845510.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nju1476202845510.htm",
             "short": "Atomic add on halfword in memory, without return",
         }
     ],
     "STADDL": [
         {
             "instr": "STADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
             "short": "Atomic add on word or doubleword in memory, without return",
         },
         {
             "instr": "STADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kyc1476202844070.htm",
             "short": "Atomic add on word or doubleword in memory, without return",
         },
     ],
     "STADDLB": [
         {
             "instr": "STADDLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/hwj1476202845050.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/hwj1476202845050.html",
             "short": "Atomic add on byte in memory, without return",
         }
     ],
     "STADDLH": [
         {
             "instr": "STADDLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nju1476202845510.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_nju1476202845510.htm",
             "short": "Atomic add on halfword in memory, without return",
         }
     ],
     "STCLR": [
         {
             "instr": "STCLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
             "short": "Atomic bit clear on word or doubleword in memory, without return",
         }
     ],
     "STCLRB": [
         {
             "instr": "STCLRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/blt1476202846250.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/blt1476202846250.html",
             "short": "Atomic bit clear on byte in memory, without return",
         }
     ],
     "STCLRH": [
         {
             "instr": "STCLRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jkh1476202846640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jkh1476202846640.htm",
             "short": "Atomic bit clear on halfword in memory, without return",
         }
     ],
     "STCLRL": [
         {
             "instr": "STCLRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
             "short": "Atomic bit clear on word or doubleword in memory, without return",
         },
         {
             "instr": "STCLRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ndn1476202845870.htm",
             "short": "Atomic bit clear on word or doubleword in memory, without return",
         },
     ],
     "STCLRLB": [
         {
             "instr": "STCLRLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/blt1476202846250.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/blt1476202846250.html",
             "short": "Atomic bit clear on byte in memory, without return",
         }
     ],
     "STCLRLH": [
         {
             "instr": "STCLRLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jkh1476202846640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jkh1476202846640.htm",
             "short": "Atomic bit clear on halfword in memory, without return",
         }
     ],
     "STEOR": [
         {
             "instr": "STEOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
             "short": "Atomic exclusive OR on word or doubleword in memory, without return",
         }
     ],
     "STEORB": [
         {
             "instr": "STEORB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_amn1476202847410.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_amn1476202847410.htm",
             "short": "Atomic exclusive OR on byte in memory, without return",
         }
     ],
     "STEORH": [
         {
             "instr": "STEORH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/vjt1476202847790.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/vjt1476202847790.html",
             "short": "Atomic exclusive OR on halfword in memory, without return",
         }
     ],
     "STEORL": [
         {
             "instr": "STEORL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
             "short": "Atomic exclusive OR on word or doubleword in memory, without return",
         },
         {
             "instr": "STEORL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/btv1476202847020.html",
             "short": "Atomic exclusive OR on word or doubleword in memory, without return",
         },
     ],
     "STEORLB": [
         {
             "instr": "STEORLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_amn1476202847410.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_amn1476202847410.htm",
             "short": "Atomic exclusive OR on byte in memory, without return",
         }
     ],
     "STEORLH": [
         {
             "instr": "STEORLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/vjt1476202847790.html",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/vjt1476202847790.html",
             "short": "Atomic exclusive OR on halfword in memory, without return",
         }
     ],
     "STLLR": [
         {
             "instr": "STLLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_owd1476202848220.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_owd1476202848220.htm",
             "short": "Store LORelease Register",
         }
     ],
     "STLLRB": [
         {
             "instr": "STLLRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_foz1476202848680.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_foz1476202848680.htm",
             "short": "Store LORelease Register Byte",
         }
     ],
     "STLLRH": [
         {
             "instr": "STLLRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bad1476202849050.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_bad1476202849050.htm",
             "short": "Store LORelease Register Halfword",
         }
     ],
     "STLR": [
         {
             "instr": "STLR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897421621.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897421621.htm",
             "short": "Store-Release Register",
         }
     ],
     "STLRB": [
         {
             "instr": "STLRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422091.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422091.htm",
             "short": "Store-Release Register Byte",
         }
     ],
     "STLRH": [
         {
             "instr": "STLRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422581.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422581.htm",
             "short": "Store-Release Register Halfword",
         }
     ],
     "STLXP": [
         {
             "instr": "STLXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422981.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897422981.htm",
             "short": "Store-Release Exclusive Pair of registers",
         }
     ],
     "STLXR": [
         {
             "instr": "STLXR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897423561.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897423561.htm",
             "short": "Store-Release Exclusive Register",
         }
     ],
     "STLXRB": [
         {
             "instr": "STLXRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897424111.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897424111.htm",
             "short": "Store-Release Exclusive Register Byte",
         }
     ],
     "STLXRH": [
         {
             "instr": "STLXRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897424681.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897424681.htm",
             "short": "Store-Release Exclusive Register Halfword",
         }
     ],
     "STNP": [
         {
             "instr": "STNP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897425671.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897425671.htm",
             "short": "Store Pair of Registers, with non-temporal hint",
         },
         {
             "instr": "STNP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897425181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897425181.htm",
             "short": "Store Pair of SIMD and FP registers, with Non-temporal hint",
         },
     ],
     "STP": [
         {
             "instr": "STP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897426751.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897426751.htm",
             "short": "Store Pair of Registers",
         },
         {
             "instr": "STP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897426241.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897426241.htm",
             "short": "Store Pair of SIMD and FP registers",
         },
     ],
     "STR": [
         {
             "instr": "STR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897427721.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897427721.htm",
             "short": "Store Register (immediate)",
         },
         {
             "instr": "STR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897428821.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897428821.htm",
             "short": "Store Register (register)",
         },
         {
             "instr": "STR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897427181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897427181.htm",
             "short": "Store SIMD and FP register (immediate offset)",
         },
         {
             "instr": "STR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897428241.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897428241.htm",
             "short": "Store SIMD and FP register (register offset)",
         },
     ],
     "STRB": [
         {
             "instr": "STRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897429421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897429421.htm",
             "short": "Store Register Byte (immediate)",
         },
         {
             "instr": "STRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897429921.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897429921.htm",
             "short": "Store Register Byte (register)",
         },
     ],
     "STRH": [
         {
             "instr": "STRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897430431.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897430431.htm",
             "short": "Store Register Halfword (immediate)",
         },
         {
             "instr": "STRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897430891.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897430891.htm",
             "short": "Store Register Halfword (register)",
         },
     ],
     "STSET": [
         {
             "instr": "STSET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
             "short": "Atomic bit set on word or doubleword in memory, without return",
         }
     ],
     "STSETB": [
         {
             "instr": "STSETB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ilx1476202864660.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ilx1476202864660.htm",
             "short": "Atomic bit set on byte in memory, without return",
         }
     ],
     "STSETH": [
         {
             "instr": "STSETH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aza1476202865070.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aza1476202865070.htm",
             "short": "Atomic bit set on halfword in memory, without return",
         }
     ],
     "STSETL": [
         {
             "instr": "STSETL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
             "short": "Atomic bit set on word or doubleword in memory, without return",
         },
         {
             "instr": "STSETL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mxe1476202864290.htm",
             "short": "Atomic bit set on word or doubleword in memory, without return",
         },
     ],
     "STSETLB": [
         {
             "instr": "STSETLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ilx1476202864660.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ilx1476202864660.htm",
             "short": "Atomic bit set on byte in memory, without return",
         }
     ],
     "STSETLH": [
         {
             "instr": "STSETLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aza1476202865070.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_aza1476202865070.htm",
             "short": "Atomic bit set on halfword in memory, without return",
         }
     ],
     "STSMAX": [
         {
             "instr": "STSMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
             "short": "Atomic signed maximum on word or doubleword in memory, without return",
         }
     ],
     "STSMAXB": [
         {
             "instr": "STSMAXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_iou1476202865800.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_iou1476202865800.htm",
             "short": "Atomic signed maximum on byte in memory, without return",
         }
     ],
     "STSMAXH": [
         {
             "instr": "STSMAXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rll1476202866270.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rll1476202866270.htm",
             "short": "Atomic signed maximum on halfword in memory, without return",
         }
     ],
     "STSMAXL": [
         {
             "instr": "STSMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
             "short": "Atomic signed maximum on word or doubleword in memory, without return",
         },
         {
             "instr": "STSMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ovl1476202865440.htm",
             "short": "Atomic signed maximum on word or doubleword in memory, without return",
         },
     ],
     "STSMAXLB": [
         {
             "instr": "STSMAXLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_iou1476202865800.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_iou1476202865800.htm",
             "short": "Atomic signed maximum on byte in memory, without return",
         }
     ],
     "STSMAXLH": [
         {
             "instr": "STSMAXLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rll1476202866270.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rll1476202866270.htm",
             "short": "Atomic signed maximum on halfword in memory, without return",
         }
     ],
     "STSMIN": [
         {
             "instr": "STSMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
             "short": "Atomic signed minimum on word or doubleword in memory, without return",
         }
     ],
     "STSMINB": [
         {
             "instr": "STSMINB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_exm1476202867040.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_exm1476202867040.htm",
             "short": "Atomic signed minimum on byte in memory, without return",
         }
     ],
     "STSMINH": [
         {
             "instr": "STSMINH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jll1476202867470.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jll1476202867470.htm",
             "short": "Atomic signed minimum on halfword in memory, without return",
         }
     ],
     "STSMINL": [
         {
             "instr": "STSMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
             "short": "Atomic signed minimum on word or doubleword in memory, without return",
         },
         {
             "instr": "STSMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rey1476202866640.htm",
             "short": "Atomic signed minimum on word or doubleword in memory, without return",
         },
     ],
     "STSMINLB": [
         {
             "instr": "STSMINLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_exm1476202867040.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_exm1476202867040.htm",
             "short": "Atomic signed minimum on byte in memory, without return",
         }
     ],
     "STSMINLH": [
         {
             "instr": "STSMINLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jll1476202867470.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_jll1476202867470.htm",
             "short": "Atomic signed minimum on halfword in memory, without return",
         }
     ],
     "STTR": [
         {
             "instr": "STTR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897431411.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897431411.htm",
             "short": "Store Register (unprivileged)",
         }
     ],
     "STTRB": [
         {
             "instr": "STTRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897432271.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897432271.htm",
             "short": "Store Register Byte (unprivileged)",
         }
     ],
     "STTRH": [
         {
             "instr": "STTRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897432781.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897432781.htm",
             "short": "Store Register Halfword (unprivileged)",
         }
     ],
     "STUMAX": [
         {
             "instr": "STUMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory, without return",
         }
     ],
     "STUMAXB": [
         {
             "instr": "STUMAXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vrl1476202870690.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vrl1476202870690.htm",
             "short": "Atomic unsigned maximum on byte in memory, without return",
         }
     ],
     "STUMAXH": [
         {
             "instr": "STUMAXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wqh1476202871060.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wqh1476202871060.htm",
             "short": "Atomic unsigned maximum on halfword in memory, without return",
         }
     ],
     "STUMAXL": [
         {
             "instr": "STUMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory, without return",
         },
         {
             "instr": "STUMAXL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_xdu1476202870220.htm",
             "short": "Atomic unsigned maximum on word or doubleword in memory, without return",
         },
     ],
     "STUMAXLB": [
         {
             "instr": "STUMAXLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vrl1476202870690.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_vrl1476202870690.htm",
             "short": "Atomic unsigned maximum on byte in memory, without return",
         }
     ],
     "STUMAXLH": [
         {
             "instr": "STUMAXLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wqh1476202871060.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wqh1476202871060.htm",
             "short": "Atomic unsigned maximum on halfword in memory, without return",
         }
     ],
     "STUMIN": [
         {
             "instr": "STUMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory, without return",
         }
     ],
     "STUMINB": [
         {
             "instr": "STUMINB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_idd1476202871790.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_idd1476202871790.htm",
             "short": "Atomic unsigned minimum on byte in memory, without return",
         }
     ],
     "STUMINH": [
         {
             "instr": "STUMINH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dug1476202872150.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dug1476202872150.htm",
             "short": "Atomic unsigned minimum on halfword in memory, without return",
         }
     ],
     "STUMINL": [
         {
             "instr": "STUMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory, without return",
         },
         {
             "instr": "STUMINL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fek1476202871420.htm",
             "short": "Atomic unsigned minimum on word or doubleword in memory, without return",
         },
     ],
     "STUMINLB": [
         {
             "instr": "STUMINLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_idd1476202871790.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_idd1476202871790.htm",
             "short": "Atomic unsigned minimum on byte in memory, without return",
         }
     ],
     "STUMINLH": [
         {
             "instr": "STUMINLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dug1476202872150.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dug1476202872150.htm",
             "short": "Atomic unsigned minimum on halfword in memory, without return",
         }
     ],
     "STUR": [
         {
             "instr": "STUR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897433771.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897433771.htm",
             "short": "Store Register (unscaled)",
         },
         {
             "instr": "STUR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897433261.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897433261.htm",
             "short": "Store SIMD and FP register (unscaled offset)",
         },
     ],
     "STURB": [
         {
             "instr": "STURB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897434181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897434181.htm",
             "short": "Store Register Byte (unscaled)",
         }
     ],
     "STURH": [
         {
             "instr": "STURH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897434641.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897434641.htm",
             "short": "Store Register Halfword (unscaled)",
         }
     ],
     "STXP": [
         {
             "instr": "STXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897435151.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897435151.htm",
             "short": "Store Exclusive Pair of registers",
         }
     ],
     "STXR": [
         {
             "instr": "STXR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897435711.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897435711.htm",
             "short": "Store Exclusive Register",
         }
     ],
     "STXRB": [
         {
             "instr": "STXRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897436241.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897436241.htm",
             "short": "Store Exclusive Register Byte",
         }
     ],
     "STXRH": [
         {
             "instr": "STXRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897436761.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897436761.htm",
             "short": "Store Exclusive Register Halfword",
         }
     ],
     "SUB": [
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897709389.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897709389.htm",
             "short": "Subtract (extended register)",
         },
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897709869.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897709869.htm",
             "short": "Subtract (immediate)",
         },
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897710249.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897710249.htm",
             "short": "Subtract (shifted register)",
         },
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897477244.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897477244.htm",
             "short": "Subtract (vector)",
         },
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582240.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582240.htm",
             "short": "Subtract (vector)",
         },
     ],
     "SUBHN": [
         {
             "instr": "SUBHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582630.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582630.htm",
             "short": "Subtract returning High Narrow",
         }
     ],
     "SUBHN2": [
         {
             "instr": "SUBHN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582630.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897582630.htm",
             "short": "Subtract returning High Narrow",
         }
     ],
     "SUBS": [
         {
             "instr": "SUBS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897710669.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897710669.htm",
             "short": "Subtract (extended register), setting flags",
         },
         {
             "instr": "SUBS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897711189.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897711189.htm",
             "short": "Subtract (immediate), setting flags",
         },
         {
             "instr": "SUBS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897711609.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897711609.htm",
             "short": "Subtract (shifted register), setting flags",
         },
     ],
     "SUQADD": [
         {
             "instr": "SUQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897477674.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897477674.htm",
             "short": "Signed saturating Accumulate of Unsigned value",
         },
         {
             "instr": "SUQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583080.htm",
             "short": "Signed saturating Accumulate of Unsigned value",
         },
     ],
     "SVC": [
         {
             "instr": "SVC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712009.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712009.htm",
             "short": "Supervisor call to allow application code to call the OS",
         }
     ],
     "SWP": [
         {
             "instr": "SWP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
         {
             "instr": "SWP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
     ],
     "SWPA": [
         {
             "instr": "SWPA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         }
     ],
     "SWPAB": [
         {
             "instr": "SWPAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
             "short": "Swap byte in memory",
         }
     ],
     "SWPAH": [
         {
             "instr": "SWPAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
             "short": "Swap halfword in memory",
         }
     ],
     "SWPAL": [
         {
             "instr": "SWPAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
         {
             "instr": "SWPAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
     ],
     "SWPALB": [
         {
             "instr": "SWPALB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
             "short": "Swap byte in memory",
         }
     ],
     "SWPALH": [
         {
             "instr": "SWPALH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
             "short": "Swap halfword in memory",
         }
     ],
     "SWPB": [
         {
             "instr": "SWPB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
             "short": "Swap byte in memory",
         }
     ],
     "SWPH": [
         {
             "instr": "SWPH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
             "short": "Swap halfword in memory",
         }
     ],
     "SWPL": [
         {
             "instr": "SWPL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
         {
             "instr": "SWPL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_rgc1476202879521.htm",
             "short": "Swap word or doubleword in memory",
         },
     ],
     "SWPLB": [
         {
             "instr": "SWPLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pbm1476202879921.htm",
             "short": "Swap byte in memory",
         }
     ],
     "SWPLH": [
         {
             "instr": "SWPLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dgh1476202880361.htm",
             "short": "Swap halfword in memory",
         }
     ],
     "SXTB": [
         {
             "instr": "SXTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712429.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712429.htm",
             "short": "Signed Extend Byte",
         }
     ],
     "SXTH": [
         {
             "instr": "SXTH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712809.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897712809.htm",
             "short": "Sign Extend Halfword",
         }
     ],
     "SXTL": [
         {
             "instr": "SXTL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583440.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583440.htm",
             "short": "Signed extend Long",
         }
     ],
     "SXTL2": [
         {
             "instr": "SXTL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583440.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583440.htm",
             "short": "Signed extend Long",
         }
     ],
     "SXTW": [
         {
             "instr": "SXTW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897713199.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897713199.htm",
             "short": "Sign Extend Word",
         }
     ],
     "SYS": [
         {
             "instr": "SYS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897713619.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897713619.htm",
             "short": "System instruction",
         }
     ],
     "SYSL": [
         {
             "instr": "SYSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714029.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714029.htm",
             "short": "System instruction with result",
         }
     ],
     "TBL": [
         {
             "instr": "TBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583840.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897583840.htm",
             "short": "Table vector Lookup",
         }
     ],
     "TBNZ": [
         {
             "instr": "TBNZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714419.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714419.htm",
             "short": "Test bit and Branch if Nonzero",
         }
     ],
     "TBX": [
         {
             "instr": "TBX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897584300.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897584300.htm",
             "short": "Table vector lookup extension",
         }
     ],
     "TBZ": [
         {
             "instr": "TBZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714819.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897714819.htm",
             "short": "Test bit and Branch if Zero",
         }
     ],
     "TLBI": [
         {
             "instr": "TLBI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897715229.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897715229.htm",
             "short": "TLB Invalidate operation",
         }
     ],
     "TRN1": [
         {
             "instr": "TRN1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897584770.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897584770.htm",
             "short": "Transpose vectors (primary)",
         }
     ],
     "TRN2": [
         {
             "instr": "TRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585170.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585170.htm",
             "short": "Transpose vectors (secondary)",
         }
     ],
     "TST": [
         {
             "instr": "TST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897715649.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897715649.htm",
             "short": ", setting the condition flags and discarding the result",
         },
         {
             "instr": "TST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716059.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716059.htm",
             "short": "Test (shifted register)",
         },
     ],
     "UABA": [
         {
             "instr": "UABA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585540.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585540.htm",
             "short": "Unsigned Absolute difference and Accumulate",
         }
     ],
     "UABAL": [
         {
             "instr": "UABAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585920.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585920.htm",
             "short": "Unsigned Absolute difference and Accumulate Long",
         }
     ],
     "UABAL2": [
         {
             "instr": "UABAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585920.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897585920.htm",
             "short": "Unsigned Absolute difference and Accumulate Long",
         }
     ],
     "UABD": [
         {
             "instr": "UABD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586430.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586430.htm",
             "short": "Unsigned Absolute Difference (vector)",
         }
     ],
     "UABDL": [
         {
             "instr": "UABDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586860.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586860.htm",
             "short": "Unsigned Absolute Difference Long",
         }
     ],
     "UABDL2": [
         {
             "instr": "UABDL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586860.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897586860.htm",
             "short": "Unsigned Absolute Difference Long",
         }
     ],
     "UADALP": [
         {
             "instr": "UADALP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587280.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587280.htm",
             "short": "Unsigned Add and Accumulate Long Pairwise",
         }
     ],
     "UADDL": [
         {
             "instr": "UADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587720.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587720.htm",
             "short": "Unsigned Add Long (vector)",
         }
     ],
     "UADDL2": [
         {
             "instr": "UADDL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587720.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897587720.htm",
             "short": "Unsigned Add Long (vector)",
         }
     ],
     "UADDLP": [
         {
             "instr": "UADDLP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897588201.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897588201.htm",
             "short": "Unsigned Add Long Pairwise",
         }
     ],
     "UADDLV": [
         {
             "instr": "UADDLV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897588601.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897588601.htm",
             "short": "Unsigned sum Long across Vector",
         }
     ],
     "UADDW": [
         {
             "instr": "UADDW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589041.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589041.htm",
             "short": "Unsigned Add Wide",
         }
     ],
     "UADDW2": [
         {
             "instr": "UADDW2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589041.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589041.htm",
             "short": "Unsigned Add Wide",
         }
     ],
     "UBFIZ": [
         {
             "instr": "UBFIZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716480.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716480.htm",
             "short": "Unsigned Bitfield Insert in Zero",
         }
     ],
     "UBFM": [
         {
             "instr": "UBFM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716900.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897716900.htm",
             "short": "Unsigned Bitfield Move",
         }
     ],
     "UBFX": [
         {
             "instr": "UBFX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897717330.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897717330.htm",
             "short": "Unsigned Bitfield Extract",
         }
     ],
     "UCVTF": [
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897637063.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897637063.htm",
             "short": "Unsigned fixed-point Convert to Floating-point (scalar)",
         },
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897637493.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897637493.htm",
             "short": "Unsigned integer Convert to Floating-point (scalar)",
         },
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478084.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478084.htm",
             "short": "Unsigned fixed-point Convert to Floating-point (vector)",
         },
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478474.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478474.htm",
             "short": "Unsigned integer Convert to Floating-point (vector)",
         },
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589431.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589431.htm",
             "short": "Unsigned fixed-point Convert to Floating-point (vector)",
         },
         {
             "instr": "UCVTF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589851.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897589851.htm",
             "short": "Unsigned integer Convert to Floating-point (vector)",
         },
     ],
     "UDIV": [
         {
             "instr": "UDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897717750.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897717750.htm",
             "short": "Unsigned Divide",
         }
     ],
     "UHADD": [
         {
             "instr": "UHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897590781.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897590781.htm",
             "short": "Unsigned Halving Add",
         }
     ],
     "UHSUB": [
         {
             "instr": "UHSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591171.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591171.htm",
             "short": "Unsigned Halving Subtract",
         }
     ],
     "UMADDL": [
         {
             "instr": "UMADDL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718150.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718150.htm",
             "short": "Unsigned Multiply-Add Long",
         }
     ],
     "UMAX": [
         {
             "instr": "UMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591571.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591571.htm",
             "short": "Unsigned Maximum (vector)",
         }
     ],
     "UMAXP": [
         {
             "instr": "UMAXP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591971.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897591971.htm",
             "short": "Unsigned Maximum Pairwise",
         }
     ],
     "UMAXV": [
         {
             "instr": "UMAXV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897592421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897592421.htm",
             "short": "Unsigned Maximum across Vector",
         }
     ],
     "UMIN": [
         {
             "instr": "UMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897592831.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897592831.htm",
             "short": "Unsigned Minimum (vector)",
         }
     ],
     "UMINP": [
         {
             "instr": "UMINP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897593241.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897593241.htm",
             "short": "Unsigned Minimum Pairwise",
         }
     ],
     "UMINV": [
         {
             "instr": "UMINV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897593651.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897593651.htm",
             "short": "Unsigned Minimum across Vector",
         }
     ],
     "UMLAL": [
         {
             "instr": "UMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594071.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594071.htm",
             "short": "Unsigned Multiply-Add Long (vector, by element)",
         },
         {
             "instr": "UMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594541.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594541.htm",
             "short": "Unsigned Multiply-Add Long (vector)",
         },
     ],
     "UMLAL2": [
         {
             "instr": "UMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594071.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594071.htm",
             "short": "Unsigned Multiply-Add Long (vector, by element)",
         },
         {
             "instr": "UMLAL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594541.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594541.htm",
             "short": "Unsigned Multiply-Add Long (vector)",
         },
     ],
     "UMLSL": [
         {
             "instr": "UMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594981.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594981.htm",
             "short": "Unsigned Multiply-Subtract Long (vector, by element)",
         },
         {
             "instr": "UMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595441.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595441.htm",
             "short": "Unsigned Multiply-Subtract Long (vector)",
         },
     ],
     "UMLSL2": [
         {
             "instr": "UMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594981.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897594981.htm",
             "short": "Unsigned Multiply-Subtract Long (vector, by element)",
         },
         {
             "instr": "UMLSL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595441.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595441.htm",
             "short": "Unsigned Multiply-Subtract Long (vector)",
         },
     ],
     "UMNEGL": [
         {
             "instr": "UMNEGL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718580.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718580.htm",
             "short": "Unsigned Multiply-Negate Long",
         }
     ],
     "UMOV": [
         {
             "instr": "UMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595861.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897595861.htm",
             "short": "Unsigned Move vector element to general-purpose register",
         }
     ],
     "UMSUBL": [
         {
             "instr": "UMSUBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718950.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897718950.htm",
             "short": "Unsigned Multiply-Subtract Long",
         }
     ],
     "UMULH": [
         {
             "instr": "UMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897719360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897719360.htm",
             "short": "Unsigned Multiply High",
         }
     ],
     "UMULL": [
         {
             "instr": "UMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897719730.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897719730.htm",
             "short": "Unsigned Multiply Long",
         },
         {
             "instr": "UMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596311.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596311.htm",
             "short": "Unsigned Multiply Long (vector, by element)",
         },
         {
             "instr": "UMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596741.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596741.htm",
             "short": "Unsigned Multiply long (vector)",
         },
     ],
     "UMULL2": [
         {
             "instr": "UMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596311.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596311.htm",
             "short": "Unsigned Multiply Long (vector, by element)",
         },
         {
             "instr": "UMULL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596741.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897596741.htm",
             "short": "Unsigned Multiply long (vector)",
         },
     ],
     "UQADD": [
         {
             "instr": "UQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478924.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897478924.htm",
             "short": "Unsigned saturating Add",
         },
         {
             "instr": "UQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597181.htm",
             "short": "Unsigned saturating Add",
         },
     ],
     "UQRSHL": [
         {
             "instr": "UQRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897479364.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897479364.htm",
             "short": "Unsigned saturating Rounding Shift Left (register)",
         },
         {
             "instr": "UQRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597601.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597601.htm",
             "short": "Unsigned saturating Rounding Shift Left (register)",
         },
     ],
     "UQRSHRN": [
         {
             "instr": "UQRSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897479784.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897479784.htm",
             "short": "Unsigned saturating Rounded Shift Right Narrow (immediate)",
         },
         {
             "instr": "UQRSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597991.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597991.htm",
             "short": "Unsigned saturating Rounded Shift Right Narrow (immediate)",
         },
     ],
     "UQRSHRN2": [
         {
             "instr": "UQRSHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597991.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897597991.htm",
             "short": "Unsigned saturating Rounded Shift Right Narrow (immediate)",
         }
     ],
     "UQSHL": [
         {
             "instr": "UQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897480224.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897480224.htm",
             "short": "Unsigned saturating Shift Left (immediate)",
         },
         {
             "instr": "UQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897480674.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897480674.htm",
             "short": "Unsigned saturating Shift Left (register)",
         },
         {
             "instr": "UQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897598411.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897598411.htm",
             "short": "Unsigned saturating Shift Left (immediate)",
         },
         {
             "instr": "UQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897598851.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897598851.htm",
             "short": "Unsigned saturating Shift Left (register)",
         },
     ],
     "UQSHRN": [
         {
             "instr": "UQSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897481194.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897481194.htm",
             "short": "Unsigned saturating Shift Right Narrow (immediate)",
         },
         {
             "instr": "UQSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897599731.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897599731.htm",
             "short": "Unsigned saturating Shift Right Narrow (immediate)",
         },
     ],
     "UQSHRN2": [
         {
             "instr": "UQSHRN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897599731.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897599731.htm",
             "short": "Unsigned saturating Shift Right Narrow (immediate)",
         }
     ],
     "UQSUB": [
         {
             "instr": "UQSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897481764.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897481764.htm",
             "short": "Unsigned saturating Subtract",
         },
         {
             "instr": "UQSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600201.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600201.htm",
             "short": "Unsigned saturating Subtract",
         },
     ],
     "UQXTN": [
         {
             "instr": "UQXTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897482274.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897482274.htm",
             "short": "Unsigned saturating extract Narrow",
         },
         {
             "instr": "UQXTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600631.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600631.htm",
             "short": "Unsigned saturating extract Narrow",
         },
     ],
     "UQXTN2": [
         {
             "instr": "UQXTN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600631.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897600631.htm",
             "short": "Unsigned saturating extract Narrow",
         }
     ],
     "URECPE": [
         {
             "instr": "URECPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601051.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601051.htm",
             "short": "Unsigned Reciprocal Estimate",
         }
     ],
     "URHADD": [
         {
             "instr": "URHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601431.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601431.htm",
             "short": "Unsigned Rounding Halving Add",
         }
     ],
     "URSHL": [
         {
             "instr": "URSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897482804.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897482804.htm",
             "short": "Unsigned Rounding Shift Left (register)",
         },
         {
             "instr": "URSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601901.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897601901.htm",
             "short": "Unsigned Rounding Shift Left (register)",
         },
     ],
     "URSHR": [
         {
             "instr": "URSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897483294.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897483294.htm",
             "short": "Unsigned Rounding Shift Right (immediate)",
         },
         {
             "instr": "URSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897602411.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897602411.htm",
             "short": "Unsigned Rounding Shift Right (immediate)",
         },
     ],
     "URSQRTE": [
         {
             "instr": "URSQRTE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897602911.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897602911.htm",
             "short": "Unsigned Reciprocal Square Root Estimate",
         }
     ],
     "URSRA": [
         {
             "instr": "URSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897483834.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897483834.htm",
             "short": "Unsigned Rounding Shift Right and Accumulate (immediate)",
         },
         {
             "instr": "URSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897603361.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897603361.htm",
             "short": "Unsigned Rounding Shift Right and Accumulate (immediate)",
         },
     ],
     "USHL": [
         {
             "instr": "USHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897484274.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897484274.htm",
             "short": "Unsigned Shift Left (register)",
         },
         {
             "instr": "USHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897603841.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897603841.htm",
             "short": "Unsigned Shift Left (register)",
         },
     ],
     "USHLL": [
         {
             "instr": "USHLL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604311.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604311.htm",
             "short": "Unsigned Shift Left Long (immediate)",
         }
     ],
     "USHLL2": [
         {
             "instr": "USHLL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604311.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604311.htm",
             "short": "Unsigned Shift Left Long (immediate)",
         }
     ],
     "USHR": [
         {
             "instr": "USHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897484794.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897484794.htm",
             "short": "Unsigned Shift Right (immediate)",
         },
         {
             "instr": "USHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604892.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897604892.htm",
             "short": "Unsigned Shift Right (immediate)",
         },
     ],
     "USQADD": [
         {
             "instr": "USQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897485324.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897485324.htm",
             "short": "Unsigned saturating Accumulate of Signed value",
         },
         {
             "instr": "USQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897605442.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897605442.htm",
             "short": "Unsigned saturating Accumulate of Signed value",
         },
     ],
     "USRA": [
         {
             "instr": "USRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897485824.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897485824.htm",
             "short": "Unsigned Shift Right and Accumulate (immediate)",
         },
         {
             "instr": "USRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897605972.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897605972.htm",
             "short": "Unsigned Shift Right and Accumulate (immediate)",
         },
     ],
     "USUBL": [
         {
             "instr": "USUBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897606512.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897606512.htm",
             "short": "Unsigned Subtract Long",
         }
     ],
     "USUBL2": [
         {
             "instr": "USUBL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897606512.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897606512.htm",
             "short": "Unsigned Subtract Long",
         }
     ],
     "USUBW": [
         {
             "instr": "USUBW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607052.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607052.htm",
             "short": "Unsigned Subtract Wide",
         }
     ],
     "USUBW2": [
         {
             "instr": "USUBW2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607052.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607052.htm",
             "short": "Unsigned Subtract Wide",
         }
     ],
     "UXTB": [
         {
             "instr": "UXTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897720190.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897720190.htm",
             "short": "Unsigned Extend Byte",
         }
     ],
     "UXTH": [
         {
             "instr": "UXTH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897720580.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897720580.htm",
             "short": "Unsigned Extend Halfword",
         }
     ],
     "UXTL": [
         {
             "instr": "UXTL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607612.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607612.htm",
             "short": "Unsigned extend Long",
         }
     ],
     "UXTL2": [
         {
             "instr": "UXTL2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607612.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897607612.htm",
             "short": "Unsigned extend Long",
         }
     ],
     "UZP1": [
         {
             "instr": "UZP1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608012.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608012.htm",
             "short": "Unzip vectors (primary)",
         }
     ],
     "UZP2": [
         {
             "instr": "UZP2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608402.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608402.htm",
             "short": "Unzip vectors (secondary)",
         }
     ],
     "WFE": [
         {
             "instr": "WFE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cus1476202785203.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_cus1476202785203.htm",
             "short": "Wait For Event",
         }
     ],
     "WFI": [
         {
             "instr": "WFI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_daw1476202785563.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_daw1476202785563.htm",
             "short": "Wait For Interrupt",
         }
     ],
     "XPACD": [
         {
             "instr": "XPACD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
             "short": "Strip Pointer Authentication Code",
         }
     ],
     "XPACI": [
         {
             "instr": "XPACI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
             "short": "Strip Pointer Authentication Code",
         }
     ],
     "XPACLRI": [
         {
             "instr": "XPACLRI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_she1476202785923.htm",
             "short": "Strip Pointer Authentication Code",
         }
     ],
     "XTN": [
         {
             "instr": "XTN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608852.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608852.htm",
             "short": "Extract Narrow",
         }
     ],
     "XTN2": [
         {
             "instr": "XTN2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608852.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897608852.htm",
             "short": "Extract Narrow",
         }
     ],
     "YIELD": [
         {
             "instr": "YIELD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_oyo1476202786273.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_oyo1476202786273.htm",
             "short": "YIELD",
         }
     ],
     "ZIP1": [
         {
             "instr": "ZIP1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897609392.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897609392.htm",
             "short": "Zip vectors (primary)",
         }
     ],
     "ZIP2": [
         {
             "instr": "ZIP2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897609872.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1427897609872.htm",
             "short": "Zip vectors (secondary)",
         }
     ],

--- a/instruction_docs/ual.py
+++ b/instruction_docs/ual.py
@@ -2,2553 +2,2553 @@ instrs = {
     "ADC": [
         {
             "instr": "ADC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889307327.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889307327.htm",
             "short": "Add with Carry",
         }
     ],
     "ADD": [
         {
             "instr": "ADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889841927.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889841927.htm",
             "short": "Add",
         }
     ],
     "ADR": [
         {
             "instr": "ADR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889307327.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889307327.htm",
             "short": "Load program or register-relative address (short range)",
         }
     ],
     "ADRL": [
         {
             "instr": "ADRL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889901839.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889901839.htm",
             "short": "Load program or register-relative address (medium range)",
         }
     ],
     "AND": [
         {
             "instr": "AND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
             "short": "Logical AND",
         }
     ],
     "ASR": [
         {
             "instr": "ASR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889924482.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889924482.htm",
             "short": "Arithmetic Shift Right",
         }
     ],
     "B": [
         {
             "instr": "B",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889934568.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889934568.htm",
             "short": "Branch",
         }
     ],
     "BFC": [
         {
             "instr": "BFC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889942851.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889942851.htm",
             "short": "Bit Field Clear and Insert",
         }
     ],
     "BFI": [
         {
             "instr": "BFI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889950424.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889950424.htm",
             "short": "Bit Field Clear and Insert",
         }
     ],
     "BIC": [
         {
             "instr": "BIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
             "short": "Bit Clear",
         }
     ],
     "BKPT": [
         {
             "instr": "BKPT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889966212.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889966212.htm",
             "short": "Software breakpoint",
         }
     ],
     "BL": [
         {
             "instr": "BL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889981170.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889981170.htm",
             "short": "Branch with Link",
         }
     ],
     "BLX": [
         {
             "instr": "BLX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889989549.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889989549.htm",
             "short": "Branch with Link, change instruction set, Branch with Link and Exchange (Non-secure)",
         }
     ],
     "BLXNS": [
         {
             "instr": "BLXNS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889989549.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889989549.htm",
             "short": "Branch with Link, change instruction set, Branch with Link and Exchange (Non-secure)",
         }
     ],
     "BX": [
         {
             "instr": "BX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889997181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889997181.htm",
             "short": "Branch, change instruction set, Branch and Exchange (Non-secure)",
         }
     ],
     "BXNS": [
         {
             "instr": "BXNS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889997181.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889997181.htm",
             "short": "Branch, change instruction set, Branch and Exchange (Non-secure)",
         }
     ],
     "CBNZ": [
         {
             "instr": "CBNZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890021484.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890021484.htm",
             "short": "Compare and Branch if {Non}Zero",
         }
     ],
     "CBZ": [
         {
             "instr": "CBZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890021484.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890021484.htm",
             "short": "Compare and Branch if {Non}Zero",
         }
     ],
     "CDP": [
         {
             "instr": "CDP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890035506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890035506.htm",
             "short": "Coprocessor Data Processing operation",
         }
     ],
     "CDP2": [
         {
             "instr": "CDP2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890035506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890035506.htm",
             "short": "Coprocessor Data Processing operation",
         }
     ],
     "CLREX": [
         {
             "instr": "CLREX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890046924.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890046924.htm",
             "short": "Clear Exclusive",
         }
     ],
     "CLZ": [
         {
             "instr": "CLZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890055713.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890055713.htm",
             "short": "Count leading zeros",
         }
     ],
     "CMN": [
         {
             "instr": "CMN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890065626.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890065626.htm",
             "short": "Compare Negative",
         }
     ],
     "CMP": [
         {
             "instr": "CMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890065626.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890065626.htm",
             "short": "Compare",
         }
     ],
     "CPS": [
         {
             "instr": "CPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
             "short": "Change Processor State",
         }
     ],
     "CPY": [
         {
             "instr": "CPY",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890087968.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890087968.htm",
             "short": "Copy",
         }
     ],
     "CRC32": [
         {
             "instr": "CRC32",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_awi1476352818103.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_awi1476352818103.htm",
             "short": "CRC32",
         }
     ],
     "CRC32C": [
         {
             "instr": "CRC32C",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwe1476352818998.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_qwe1476352818998.htm",
             "short": "CRC32C",
         }
     ],
     "DBG": [
         {
             "instr": "DBG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890104002.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890104002.htm",
             "short": "Debug",
         }
     ],
     "DCPS1": [
         {
             "instr": "DCPS1",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
             "short": "Debug switch to exception level 1",
         }
     ],
     "DCPS2": [
         {
             "instr": "DCPS2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
             "short": "Debug switch to exception level 2",
         }
     ],
     "DCPS3": [
         {
             "instr": "DCPS3",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890075641.htm",
             "short": "Debug switch to exception level 3",
         }
     ],
     "DMB": [
         {
             "instr": "DMB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890114571.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890114571.htm",
             "short": "Data Memory Barrier",
         }
     ],
     "DSB": [
         {
             "instr": "DSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
             "short": "Data Synchronization Barrier",
         },
         {
             "instr": "DSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
             "short": "Data Synchronization Barrier",
         },
     ],
     "EOR": [
         {
             "instr": "EOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890133290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890133290.htm",
             "short": "Exclusive OR",
         }
     ],
     "ERET": [
         {
             "instr": "ERET",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890145994.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890145994.htm",
             "short": "Exception Return",
         }
     ],
     "ESB": [
         {
             "instr": "ESB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wpv1476352823512.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_wpv1476352823512.htm",
             "short": "Error Synchronization Barrier",
         }
     ],
     "FLDMDBX": [
         {
             "instr": "FLDMDBX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kqy1476352931459.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kqy1476352931459.htm",
             "short": "FLDMX",
         }
     ],
     "FLDMIAX": [
         {
             "instr": "FLDMIAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kqy1476352931459.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_kqy1476352931459.htm",
             "short": "FLDMX",
         }
     ],
     "FSTMDBX": [
         {
             "instr": "FSTMDBX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fgf1476352931779.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fgf1476352931779.htm",
             "short": "FSTMX",
         }
     ],
     "FSTMIAX": [
         {
             "instr": "FSTMIAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fgf1476352931779.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_fgf1476352931779.htm",
             "short": "FSTMX",
         }
     ],
     "HLT": [
         {
             "instr": "HLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425564187099.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425564187099.htm",
             "short": "Halting breakpoint",
         }
     ],
     "HVC": [
         {
             "instr": "HVC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890193980.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890193980.htm",
             "short": "Hypervisor Call",
         }
     ],
     "ISB": [
         {
             "instr": "ISB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890205000.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890205000.htm",
             "short": "Instruction Synchronization Barrier",
         }
     ],
     "IT": [
         {
             "instr": "IT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890218120.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890218120.htm",
             "short": "If-Then",
         }
     ],
     "LDA": [
         {
             "instr": "LDA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
             "short": "Load-Acquire Register Word",
         }
     ],
     "LDAB": [
         {
             "instr": "LDAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
             "short": "Load-Acquire Register Byte",
         }
     ],
     "LDAEX": [
         {
             "instr": "LDAEX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
             "short": "Load-Acquire Register Exclusive Word",
         }
     ],
     "LDAEXB": [
         {
             "instr": "LDAEXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
             "short": "Load-Acquire Register Exclusive Byte",
         }
     ],
     "LDAEXD": [
         {
             "instr": "LDAEXD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
             "short": "Load-Acquire Register Exclusive Doubleword",
         }
     ],
     "LDAEXH": [
         {
             "instr": "LDAEXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433203404.htm",
             "short": "Load-Acquire Register Exclusive Halfword",
         }
     ],
     "LDAH": [
         {
             "instr": "LDAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429112691581.htm",
             "short": "Load-Acquire Register Halfword",
         }
     ],
     "LDC": [
         {
             "instr": "LDC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890230375.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890230375.htm",
             "short": "Load Coprocessor",
         }
     ],
     "LDC2": [
         {
             "instr": "LDC2",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890230375.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890230375.htm",
             "short": "Load Coprocessor",
         }
     ],
     "LDM": [
         {
             "instr": "LDM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890240379.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890240379.htm",
             "short": "Load Multiple registers",
         }
     ],
     "LDR": [
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with word",
         },
         {
             "instr": "LDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
             "short": "Load Register pseudo-instruction",
         },
     ],
     "LDRB": [
         {
             "instr": "LDRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with Byte",
         }
     ],
     "LDRBT": [
         {
             "instr": "LDRBT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
             "short": "Load Register with Byte, user mode",
         }
     ],
     "LDRD": [
         {
             "instr": "LDRD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Registers with two words",
         }
     ],
     "LDREX": [
         {
             "instr": "LDREX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
             "short": "Load Register Exclusive Word",
         }
     ],
     "LDREXB": [
         {
             "instr": "LDREXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
             "short": "Load Register Exclusive Byte",
         }
     ],
     "LDREXD": [
         {
             "instr": "LDREXD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
             "short": "Load Register Exclusive Doubleword",
         }
     ],
     "LDREXH": [
         {
             "instr": "LDREXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890318276.htm",
             "short": "Load Register Exclusive Halfword",
         }
     ],
     "LDRH": [
         {
             "instr": "LDRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with Halfword",
         }
     ],
     "LDRHT": [
         {
             "instr": "LDRHT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with Halfword, user mode",
         }
     ],
     "LDRSB": [
         {
             "instr": "LDRSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
             "short": "Load Register with Signed Byte",
         }
     ],
     "LDRSBT": [
         {
             "instr": "LDRSBT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890123364.htm",
             "short": "Load Register with Signed Byte, user mode",
         }
     ],
     "LDRSH": [
         {
             "instr": "LDRSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with Signed Halfword",
         }
     ],
     "LDRSHT": [
         {
             "instr": "LDRSHT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with Signed Halfword, user mode",
         }
     ],
     "LDRT": [
         {
             "instr": "LDRT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Load Register with word, user mode",
         }
     ],
     "LSL": [
         {
             "instr": "LSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890373464.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890373464.htm",
             "short": "Logical Shift Left",
         }
     ],
     "LSR": [
         {
             "instr": "LSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890383924.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890383924.htm",
             "short": "Logical Shift Right",
         }
     ],
     "MCR": [
         {
             "instr": "MCR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890395091.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890395091.htm",
             "short": "Move from Register to Coprocessor",
         }
     ],
     "MCRR": [
         {
             "instr": "MCRR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890404678.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890404678.htm",
             "short": "Move from Registers to Coprocessor",
         }
     ],
     "MLA": [
         {
             "instr": "MLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890415957.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890415957.htm",
             "short": "Multiply Accumulate",
         }
     ],
     "MLS": [
         {
             "instr": "MLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890428981.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890428981.htm",
             "short": "Multiply and Subtract",
         }
     ],
     "MOV": [
         {
             "instr": "MOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890440026.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890440026.htm",
             "short": "Move",
         }
     ],
     "MOV32": [
         {
             "instr": "MOV32",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890455346.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890455346.htm",
             "short": "Move 32-bit immediate to register",
         }
     ],
     "MOVT": [
         {
             "instr": "MOVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890480348.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890480348.htm",
             "short": "Move Top",
         }
     ],
     "MRC": [
         {
             "instr": "MRC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890493551.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890493551.htm",
             "short": "Move from Coprocessor to Register",
         }
     ],
     "MRRC": [
         {
             "instr": "MRRC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890504536.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890504536.htm",
             "short": "Move from Coprocessor to Registers",
         }
     ],
     "MRS": [
         {
             "instr": "MRS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
             "short": "Move from PSR to Register",
         },
         {
             "instr": "MRS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
             "short": "Move from system Coprocessor to Register",
         },
     ],
     "MSR": [
         {
             "instr": "MSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
             "short": "Move from Register to PSR",
         },
         {
             "instr": "MSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890292360.htm",
             "short": "Move from Register to system Coprocessor",
         },
     ],
     "MUL": [
         {
             "instr": "MUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898077663.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898077663.htm",
             "short": "Multiply",
         }
     ],
     "MVN": [
         {
             "instr": "MVN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898090605.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898090605.htm",
             "short": "Move Not",
         }
     ],
     "NEG": [
         {
             "instr": "NEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898099992.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898099992.htm",
             "short": "Negate",
         }
     ],
     "NOP": [
         {
             "instr": "NOP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898111637.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898111637.htm",
             "short": "No Operation",
         }
     ],
     "ORN": [
         {
             "instr": "ORN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890133290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890133290.htm",
             "short": "Logical OR NOT",
         }
     ],
     "ORR": [
         {
             "instr": "ORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
             "short": "Logical OR",
         }
     ],
     "PKHBT": [
         {
             "instr": "PKHBT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898999025.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898999025.htm",
             "short": "Pack Halfwords",
         }
     ],
     "PKHTB": [
         {
             "instr": "PKHTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898999025.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898999025.htm",
             "short": "Pack Halfwords",
         }
     ],
     "PLD": [
         {
             "instr": "PLD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
             "short": "Preload Data",
         }
     ],
     "PLDW": [
         {
             "instr": "PLDW",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
             "short": "Preload Data with intent to Write",
         }
     ],
     "PLI": [
         {
             "instr": "PLI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899018492.htm",
             "short": "Preload Instruction",
         }
     ],
     "POP": [
         {
             "instr": "POP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899030586.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899030586.htm",
             "short": "POP registers from stack",
         }
     ],
     "PUSH": [
         {
             "instr": "PUSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899044621.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899044621.htm",
             "short": "PUSH registers to stack",
         }
     ],
     "QADD": [
         {
             "instr": "QADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899860328.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899860328.htm",
             "short": "Saturating arithmetic",
         }
     ],
     "QADD16": [
         {
             "instr": "QADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899883374.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899883374.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "QADD8": [
         {
             "instr": "QADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899871217.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899871217.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "QASX": [
         {
             "instr": "QASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899892360.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899892360.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "QDADD": [
         {
             "instr": "QDADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899904388.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899904388.htm",
             "short": "Saturating arithmetic",
         }
     ],
     "QDSUB": [
         {
             "instr": "QDSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899914201.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425899914201.htm",
             "short": "Saturating arithmetic",
         }
     ],
     "QSAX": [
         {
             "instr": "QSAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901210287.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901210287.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "QSUB": [
         {
             "instr": "QSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901227555.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901227555.htm",
             "short": "Saturating arithmetic",
         }
     ],
     "QSUB16": [
         {
             "instr": "QSUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901246838.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901246838.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "QSUB8": [
         {
             "instr": "QSUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901237598.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901237598.htm",
             "short": "Parallel signed saturating arithmetic",
         }
     ],
     "RBIT": [
         {
             "instr": "RBIT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
             "short": "Reverse Bits",
         }
     ],
     "REV": [
         {
             "instr": "REV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901506568.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901506568.htm",
             "short": "Reverse byte order",
         }
     ],
     "REV16": [
         {
             "instr": "REV16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901520514.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901520514.htm",
             "short": "Reverse byte order",
         }
     ],
     "REVSH": [
         {
             "instr": "REVSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901584041.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901584041.htm",
             "short": "Reverse byte order",
         }
     ],
     "RFE": [
         {
             "instr": "RFE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901533481.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901533481.htm",
             "short": "Return From Exception",
         }
     ],
     "ROR": [
         {
             "instr": "ROR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901541467.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901541467.htm",
             "short": "Rotate Right Register",
         }
     ],
     "RRX": [
         {
             "instr": "RRX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901551183.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901551183.htm",
             "short": "Rotate Right with Extend",
         }
     ],
     "RSB": [
         {
             "instr": "RSB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901593052.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901593052.htm",
             "short": "Reverse Subtract",
         }
     ],
     "RSC": [
         {
             "instr": "RSC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901602609.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901602609.htm",
             "short": "Reverse Subtract with Carry",
         }
     ],
     "SADD16": [
         {
             "instr": "SADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906530739.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906530739.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "SADD8": [
         {
             "instr": "SADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906514185.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906514185.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "SASX": [
         {
             "instr": "SASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906539458.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906539458.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "SBC": [
         {
             "instr": "SBC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906548297.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906548297.htm",
             "short": "Subtract with Carry",
         }
     ],
     "SBFX": [
         {
             "instr": "SBFX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906593664.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906593664.htm",
             "short": "Signed Bit Field eXtract",
         }
     ],
     "SDIV": [
         {
             "instr": "SDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906604697.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906604697.htm",
             "short": "Signed Divide",
         }
     ],
     "SEL": [
         {
             "instr": "SEL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906625495.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906625495.htm",
             "short": "Select bytes according to APSR GE flags",
         }
     ],
     "SETEND": [
         {
             "instr": "SETEND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906645592.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906645592.htm",
             "short": "Set Endianness for memory accesses",
         }
     ],
     "SETPAN": [
         {
             "instr": "SETPAN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_eai1476352878905.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_eai1476352878905.htm",
             "short": "Set Privileged Access Never",
         }
     ],
     "SEV": [
         {
             "instr": "SEV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906657222.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425906657222.htm",
             "short": "Set Event",
         }
     ],
     "SEVL": [
         {
             "instr": "SEVL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429177774796.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429177774796.htm",
             "short": "Set Event Locally",
         }
     ],
     "SG": [
         {
             "instr": "SG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175165109.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175165109.htm",
             "short": "Secure Gateway",
         }
     ],
     "SHADD16": [
         {
             "instr": "SHADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910454133.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910454133.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SHADD8": [
         {
             "instr": "SHADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910435007.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910435007.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SHASX": [
         {
             "instr": "SHASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910463798.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910463798.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SHSAX": [
         {
             "instr": "SHSAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910473096.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910473096.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SHSUB16": [
         {
             "instr": "SHSUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910559031.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910559031.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SHSUB8": [
         {
             "instr": "SHSUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910482480.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910482480.htm",
             "short": "Parallel Signed Halving arithmetic",
         }
     ],
     "SMC": [
         {
             "instr": "SMC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910897272.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910897272.htm",
             "short": "Secure Monitor Call",
         }
     ],
     "SMLAD": [
         {
             "instr": "SMLAD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910917679.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910917679.htm",
             "short": "Dual Signed Multiply Accumulate",
         }
     ],
     "SMLAL": [
         {
             "instr": "SMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910926465.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910926465.htm",
             "short": "Signed Multiply Accumulate (64 <= 64 + 32 x 32)",
         }
     ],
     "SMLALD": [
         {
             "instr": "SMLALD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910935569.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910935569.htm",
             "short": "Dual Signed Multiply Accumulate Long",
         }
     ],
     "SMLALxy": [
         {
             "instr": "SMLALxy",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910945100.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910945100.htm",
             "short": "Signed Multiply Accumulate (64 <= 64 + 16 x 16)",
         }
     ],
     "SMLAWy": [
         {
             "instr": "SMLAWy",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910954185.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910954185.htm",
             "short": "Signed Multiply with Accumulate (32 <= 32 x 16 + 32)",
         }
     ],
     "SMLAxy": [
         {
             "instr": "SMLAxy",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910907132.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910907132.htm",
             "short": "Signed Multiply with Accumulate (32 <= 16 x 16 + 32)",
         }
     ],
     "SMLSD": [
         {
             "instr": "SMLSD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910962669.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910962669.htm",
             "short": "Dual Signed Multiply Subtract Accumulate",
         }
     ],
     "SMLSLD": [
         {
             "instr": "SMLSLD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910971648.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910971648.htm",
             "short": "Dual Signed Multiply Subtract Accumulate Long",
         }
     ],
     "SMMLA": [
         {
             "instr": "SMMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910984298.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910984298.htm",
             "short": "Signed top word Multiply with Accumulate (32 <= TopWord(32 x 32 + 32))",
         }
     ],
     "SMMLS": [
         {
             "instr": "SMMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910992502.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425910992502.htm",
             "short": "Signed top word Multiply with Subtract (32 <= TopWord(32 - 32 x 32))",
         }
     ],
     "SMMUL": [
         {
             "instr": "SMMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911003437.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911003437.htm",
             "short": "Signed top word Multiply (32 <= TopWord(32 x 32))",
         }
     ],
     "SMUAD": [
         {
             "instr": "SMUAD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911015421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911015421.htm",
             "short": "Dual Signed Multiply and Add product",
         }
     ],
     "SMULL": [
         {
             "instr": "SMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911036135.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911036135.htm",
             "short": "Signed Multiply (64 <= 32 x 32)",
         }
     ],
     "SMULWy": [
         {
             "instr": "SMULWy",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911044506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911044506.htm",
             "short": "Signed Multiply (32 <= 32 x 16)",
         }
     ],
     "SMULxy": [
         {
             "instr": "SMULxy",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911027047.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911027047.htm",
             "short": "Signed Multiply (32 <= 16 x 16)",
         }
     ],
     "SMUSD": [
         {
             "instr": "SMUSD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911055519.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911055519.htm",
             "short": "Dual Signed Multiply and Subtract product",
         }
     ],
     "SRS": [
         {
             "instr": "SRS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911938187.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911938187.htm",
             "short": "Store Return State",
         }
     ],
     "SSAT": [
         {
             "instr": "SSAT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911950587.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911950587.htm",
             "short": "Signed Saturate",
         }
     ],
     "SSAT16": [
         {
             "instr": "SSAT16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911959532.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911959532.htm",
             "short": "Signed Saturate, parallel halfwords",
         }
     ],
     "SSAX": [
         {
             "instr": "SSAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911968531.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425911968531.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "SSUB16": [
         {
             "instr": "SSUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425912033174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425912033174.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "SSUB8": [
         {
             "instr": "SSUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425912022655.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425912022655.htm",
             "short": "Parallel Signed arithmetic",
         }
     ],
     "STC": [
         {
             "instr": "STC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890529837.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890529837.htm",
             "short": "Store Coprocessor",
         }
     ],
     "STL": [
         {
             "instr": "STL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
             "short": "Store-Release Word",
         }
     ],
     "STLB": [
         {
             "instr": "STLB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
             "short": "Store-Release Byte",
         }
     ],
     "STLEX": [
         {
             "instr": "STLEX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
             "short": "Store-Release Exclusive Word",
         }
     ],
     "STLEXB": [
         {
             "instr": "STLEXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
             "short": "Store-Release Exclusive Byte",
         }
     ],
     "STLEXD": [
         {
             "instr": "STLEXD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
             "short": "Store-Release Exclusive Doubleword",
         }
     ],
     "STLEXH": [
         {
             "instr": "STLEXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890542287.htm",
             "short": "Store-Release Exclusive Halfword",
         }
     ],
     "STLH": [
         {
             "instr": "STLH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1429113453813.htm",
             "short": "Store-Release Halfword",
         }
     ],
     "STM": [
         {
             "instr": "STM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890554593.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890554593.htm",
             "short": "Store Multiple registers",
         }
     ],
     "STR": [
         {
             "instr": "STR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
             "short": "Store Register with word",
         }
     ],
     "STRB": [
         {
             "instr": "STRB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914119973.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914119973.htm",
             "short": "Store Register with Byte",
         }
     ],
     "STRBT": [
         {
             "instr": "STRBT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901492903.htm",
             "short": "Store Register with Byte, user mode",
         }
     ],
     "STRD": [
         {
             "instr": "STRD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
             "short": "Store Registers with two words",
         }
     ],
     "STREX": [
         {
             "instr": "STREX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
             "short": "Store Register Exclusive Word",
         }
     ],
     "STREXB": [
         {
             "instr": "STREXB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
             "short": "Store Register Exclusive Byte",
         }
     ],
     "STREXD": [
         {
             "instr": "STREXD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
             "short": "Store Register Exclusive Doubleword",
         }
     ],
     "STREXH": [
         {
             "instr": "STREXH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425890604489.htm",
             "short": "Store Register Exclusive Halfword",
         }
     ],
     "STRH": [
         {
             "instr": "STRH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
             "short": "Store Register with Halfword",
         }
     ],
     "STRHT": [
         {
             "instr": "STRHT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
             "short": "Store Register with Halfword, user mode",
         }
     ],
     "STRT": [
         {
             "instr": "STRT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289990966.htm",
             "short": "Store Register with word, user mode",
         }
     ],
     "SUB": [
         {
             "instr": "SUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914016900.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914016900.htm",
             "short": "Subtract",
         }
     ],
     "SUBS": [
         {
             "instr": "SUBS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914041468.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914041468.htm",
             "short": "Exception return, no stack",
         }
     ],
     "SVC": [
         {
             "instr": "SVC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914052313.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914052313.htm",
             "short": "Supervisor Call",
         }
     ],
     "SXTAB": [
         {
             "instr": "SXTAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914089623.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914089623.htm",
             "short": "Signed extend, with Addition",
         }
     ],
     "SXTAB16": [
         {
             "instr": "SXTAB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914101520.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914101520.htm",
             "short": "Signed extend, with Addition",
         }
     ],
     "SXTAH": [
         {
             "instr": "SXTAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914111505.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914111505.htm",
             "short": "Signed extend, with Addition",
         }
     ],
     "SXTB": [
         {
             "instr": "SXTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914119973.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914119973.htm",
             "short": "Signed extend",
         }
     ],
     "SXTB16": [
         {
             "instr": "SXTB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914128788.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914128788.htm",
             "short": "Signed extend",
         }
     ],
     "SXTH": [
         {
             "instr": "SXTH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914139870.htm",
             "short": "Signed extend",
         }
     ],
     "SYS": [
         {
             "instr": "SYS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914149910.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914149910.htm",
             "short": "Execute System coprocessor instruction",
         }
     ],
     "TBB": [
         {
             "instr": "TBB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914159689.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914159689.htm",
             "short": "Table Branch Byte",
         }
     ],
     "TBH": [
         {
             "instr": "TBH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914159689.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914159689.htm",
             "short": "Table Branch Halfword",
         }
     ],
     "TEQ": [
         {
             "instr": "TEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914168242.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914168242.htm",
             "short": "Test Equivalence",
         }
     ],
     "TST": [
         {
             "instr": "TST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914177163.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425914177163.htm",
             "short": "Test",
         }
     ],
     "TT": [
         {
             "instr": "TT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
             "short": "Test Target (Alternate Domain, Unprivileged)",
         }
     ],
     "TTA": [
         {
             "instr": "TTA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
             "short": "Test Target (Alternate Domain, Unprivileged)",
         }
     ],
     "TTAT": [
         {
             "instr": "TTAT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
             "short": "Test Target (Alternate Domain, Unprivileged)",
         }
     ],
     "TTT": [
         {
             "instr": "TTT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1447175167080.htm",
             "short": "Test Target (Alternate Domain, Unprivileged)",
         }
     ],
     "UADD16": [
         {
             "instr": "UADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915350745.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915350745.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "UADD8": [
         {
             "instr": "UADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915337975.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915337975.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "UASX": [
         {
             "instr": "UASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915362627.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915362627.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "UBFX": [
         {
             "instr": "UBFX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915375380.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915375380.htm",
             "short": "Unsigned Bit Field eXtract",
         }
     ],
     "UDF": [
         {
             "instr": "UDF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zme1476352914494.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zme1476352914494.htm",
             "short": "Permanently Undefined",
         }
     ],
     "UDIV": [
         {
             "instr": "UDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915385325.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425915385325.htm",
             "short": "Unsigned Divide",
         }
     ],
     "UHADD16": [
         {
             "instr": "UHADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916046129.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916046129.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UHADD8": [
         {
             "instr": "UHADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916032545.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916032545.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UHASX": [
         {
             "instr": "UHASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916058137.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916058137.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UHSAX": [
         {
             "instr": "UHSAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916068035.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916068035.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UHSUB16": [
         {
             "instr": "UHSUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916084548.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916084548.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UHSUB8": [
         {
             "instr": "UHSUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916075981.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916075981.htm",
             "short": "Parallel Unsigned Halving arithmetic",
         }
     ],
     "UMAAL": [
         {
             "instr": "UMAAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916094062.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916094062.htm",
             "short": "Unsigned Multiply Accumulate Accumulate Long",
         }
     ],
     "UMLAL": [
         {
             "instr": "UMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916104084.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916104084.htm",
             "short": "Unsigned Multiply Accumulate",
         }
     ],
     "UMULL": [
         {
             "instr": "UMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916119892.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916119892.htm",
             "short": "Unsigned Multiply",
         }
     ],
     "UQADD16": [
         {
             "instr": "UQADD16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916577462.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916577462.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "UQADD8": [
         {
             "instr": "UQADD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916563479.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916563479.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "UQASX": [
         {
             "instr": "UQASX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916586427.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916586427.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "UQSAX": [
         {
             "instr": "UQSAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916594735.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916594735.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "UQSUB16": [
         {
             "instr": "UQSUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916613661.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916613661.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "UQSUB8": [
         {
             "instr": "UQSUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916604231.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916604231.htm",
             "short": "Parallel Unsigned Saturating arithmetic",
         }
     ],
     "USAD8": [
         {
             "instr": "USAD8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916622373.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916622373.htm",
             "short": "Unsigned Sum of Absolute Differences",
         }
     ],
     "USADA8": [
         {
             "instr": "USADA8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916631159.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916631159.htm",
             "short": "Accumulate Unsigned Sum of Absolute Differences",
         }
     ],
     "USAT": [
         {
             "instr": "USAT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916641790.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916641790.htm",
             "short": "Unsigned Saturate",
         }
     ],
     "USAT16": [
         {
             "instr": "USAT16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916654170.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916654170.htm",
             "short": "Unsigned Saturate, parallel halfwords",
         }
     ],
     "USAX": [
         {
             "instr": "USAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916663991.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425916663991.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "USUB16": [
         {
             "instr": "USUB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917062704.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917062704.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "USUB8": [
         {
             "instr": "USUB8",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917046103.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917046103.htm",
             "short": "Parallel Unsigned arithmetic",
         }
     ],
     "UXTAB": [
         {
             "instr": "UXTAB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917070663.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917070663.htm",
             "short": "Unsigned extend with Addition",
         }
     ],
     "UXTAB16": [
         {
             "instr": "UXTAB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917078324.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917078324.htm",
             "short": "Unsigned extend with Addition",
         }
     ],
     "UXTAH": [
         {
             "instr": "UXTAH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917086082.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917086082.htm",
             "short": "Unsigned extend with Addition",
         }
     ],
     "UXTB": [
         {
             "instr": "UXTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917094057.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917094057.htm",
             "short": "Unsigned extend",
         }
     ],
     "UXTB16": [
         {
             "instr": "UXTB16",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917102054.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917102054.htm",
             "short": "Unsigned extend",
         }
     ],
     "UXTH": [
         {
             "instr": "UXTH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917110918.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917110918.htm",
             "short": "Unsigned extend",
         }
     ],
     "VABA": [
         {
             "instr": "VABA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289938635.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289938635.htm",
             "short": "Absolute difference and Accumulate",
         }
     ],
     "VABD": [
         {
             "instr": "VABD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289938965.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289938965.htm",
             "short": "Absolute Difference",
         }
     ],
     "VABS": [
         {
             "instr": "VABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289939344.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289939344.htm",
             "short": "Absolute value",
         },
         {
             "instr": "VABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289939344.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289939344.htm",
             "short": "Absolute value",
         },
     ],
     "VACGE": [
         {
             "instr": "VACGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Absolute Compare Greater than or Equal",
         }
     ],
     "VACGT": [
         {
             "instr": "VACGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Absolute Compare Greater Than",
         }
     ],
     "VACLE": [
         {
             "instr": "VACLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Absolute Compare Less than or Equal",
         }
     ],
     "VACLT": [
         {
             "instr": "VACLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Absolute Compare Less Than (pseudo-instructions)",
         }
     ],
     "VADD": [
         {
             "instr": "VADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940984.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940984.htm",
             "short": "Add",
         },
         {
             "instr": "VADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940984.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940984.htm",
             "short": "Add",
         },
     ],
     "VADDHN": [
         {
             "instr": "VADDHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289941334.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289941334.htm",
             "short": "Add, select High half",
         }
     ],
     "VAND": [
         {
             "instr": "VAND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
             "short": "Bitwise AND",
         },
         {
             "instr": "VAND",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889912421.htm",
             "short": "Bitwise AND (pseudo-instruction)",
         },
     ],
     "VBIC": [
         {
             "instr": "VBIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
             "short": "Bitwise Bit Clear (register)",
         },
         {
             "instr": "VBIC",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425889958629.htm",
             "short": "Bitwise Bit Clear (immediate)",
         },
     ],
     "VBIF": [
         {
             "instr": "VBIF",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289943534.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289943534.htm",
             "short": "Bitwise Insert if False",
         }
     ],
     "VBIT": [
         {
             "instr": "VBIT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289943884.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289943884.htm",
             "short": "Bitwise Insert if True",
         }
     ],
     "VBSL": [
         {
             "instr": "VBSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
             "short": "Select",
         }
     ],
     "VCADD": [
         {
             "instr": "VCADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydp1476352944870.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ydp1476352944870.htm",
             "short": "Vector Complex Add",
         }
     ],
     "VCEQ": [
         {
             "instr": "VCEQ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Equal",
         }
     ],
     "VCGE": [
         {
             "instr": "VCGE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Greater than or Equal",
         }
     ],
     "VCGT": [
         {
             "instr": "VCGT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Greater Than",
         }
     ],
     "VCLE": [
         {
             "instr": "VCLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Less than or Equal",
         },
         {
             "instr": "VCLE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Less than or Equal",
         },
     ],
     "VCLS": [
         {
             "instr": "VCLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289947693.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289947693.htm",
             "short": "Count Leading Sign bits",
         }
     ],
     "VCLT": [
         {
             "instr": "VCLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Less Than",
         },
         {
             "instr": "VCLT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289940174.htm",
             "short": "Compare Less Than (pseudo-instruction)",
         },
     ],
     "VCLZ": [
         {
             "instr": "VCLZ",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289948783.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289948783.htm",
             "short": "Count Leading Zeros",
         }
     ],
     "VCMLA": [
         {
             "instr": "VCMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_acv1476352950970.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_acv1476352950970.htm",
             "short": "Vector Complex Multiply Accumulate",
         }
     ],
     "VCMLA (by element)": [
         {
             "instr": "VCMLA (by element)",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mkm1476352951310.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_mkm1476352951310.htm",
             "short": "Vector Complex Multiply Accumulate (by element)",
         }
     ],
     "VCMP": [
         {
             "instr": "VCMP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949173.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949173.htm",
             "short": "Compare",
         }
     ],
     "VCMPE": [
         {
             "instr": "VCMPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949173.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949173.htm",
             "short": "Compare",
         }
     ],
     "VCNT": [
         {
             "instr": "VCNT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949533.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289949533.htm",
             "short": "Count set bits",
         }
     ],
     "VCVT": [
         {
             "instr": "VCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert fixed-point or integer to floating-point, floating-point to integer or fixed-point",
         },
         {
             "instr": "VCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert floating-point to integer with directed rounding modes",
         },
         {
             "instr": "VCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert between half-precision and single-precision floating-point numbers",
         },
         {
             "instr": "VCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert between single-precision and double-precision",
         },
     ],
     "VCVTB": [
         {
             "instr": "VCVTB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert between half-precision and single-precision floating-point",
         }
     ],
     "VCVTT": [
         {
             "instr": "VCVTT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Convert between half-precision and single-precision floating-point",
         }
     ],
     "VDIV": [
         {
             "instr": "VDIV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952072.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952072.htm",
             "short": "Divide",
         }
     ],
     "VDUP": [
         {
             "instr": "VDUP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952392.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952392.htm",
             "short": "Duplicate scalar to all lanes of vector",
         }
     ],
     "VEOR": [
         {
             "instr": "VEOR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
             "short": "Bitwise Exclusive OR",
         }
     ],
     "VEXT": [
         {
             "instr": "VEXT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953622.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953622.htm",
             "short": "Extract",
         }
     ],
     "VFMA": [
         {
             "instr": "VFMA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
             "short": "Fused Multiply Accumulate",
         },
         {
             "instr": "VFMA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
             "short": "Fused multiply accumulate",
         },
     ],
     "VFMS": [
         {
             "instr": "VFMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
             "short": "Fused Multiply Subtract",
         },
         {
             "instr": "VFMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
             "short": "Fused multiply subtract",
         },
     ],
     "VFNMA": [
         {
             "instr": "VFNMA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289954342.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289954342.htm",
             "short": "Fused multiply accumulate with negation",
         }
     ],
     "VFNMS": [
         {
             "instr": "VFNMS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289953962.htm",
             "short": "Fused multiply subtract with negation",
         }
     ],
     "VHADD": [
         {
             "instr": "VHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289954742.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289954742.htm",
             "short": "Halving Add",
         }
     ],
     "VHSUB": [
         {
             "instr": "VHSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289955132.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289955132.htm",
             "short": "Halving Subtract",
         }
     ],
     "VJCVT": [
         {
             "instr": "VJCVT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ici1476352964675.htm",
             "short": "Javascript Convert to signed fixed-point, rounding toward Zero",
         }
     ],
     "VLD": [
         {
             "instr": "VLD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289956822.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289956822.htm",
             "short": "Vector Load",
         }
     ],
     "VLDM": [
         {
             "instr": "VLDM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289956822.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289956822.htm",
             "short": "Extension register load multiple",
         }
     ],
     "VLDR": [
         {
             "instr": "VLDR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289957202.htm",
             "short": "Extension register load",
         }
     ],
     "VLLDM": [
         {
             "instr": "VLLDM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ibk1480518609451.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_ibk1480518609451.htm",
             "short": "Floating-point Lazy Load Multiple",
         }
     ],
     "VLSTM": [
         {
             "instr": "VLSTM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zth1480518611751.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_zth1480518611751.htm",
             "short": "Floating-point Lazy Store Multiple",
         }
     ],
     "VMAX": [
         {
             "instr": "VMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958291.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958291.htm",
             "short": "Maximum",
         }
     ],
     "VMAXNM": [
         {
             "instr": "VMAXNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
             "short": "Maximum, consistent with IEEE 754-2008",
         },
         {
             "instr": "VMAXNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
             "short": "Maximum, Minimum, consistent with IEEE 754-2008",
         },
     ],
     "VMIN": [
         {
             "instr": "VMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958291.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958291.htm",
             "short": "Minimum",
         }
     ],
     "VMINNM": [
         {
             "instr": "VMINNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
             "short": "Minimum, consistent with IEEE 754-2008",
         },
         {
             "instr": "VMINNM",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433209634.htm",
             "short": "Maximum, Minimum, consistent with IEEE 754-2008",
         },
     ],
     "VMLA": [
         {
             "instr": "VMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
             "short": "Multiply Accumulate",
         },
         {
             "instr": "VMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
             "short": "Multiply Accumulate",
         },
         {
             "instr": "VMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
             "short": "Multiply accumulate",
         },
     ],
     "VMLS": [
         {
             "instr": "VMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
             "short": "Multiply Subtract (vector)",
         },
         {
             "instr": "VMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
             "short": "Multiply Subtract (by scalar)",
         },
         {
             "instr": "VMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
             "short": "Multiply subtract",
         },
     ],
     "VMOV": [
         {
             "instr": "VMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
             "short": "Move (immediate)",
         },
         {
             "instr": "VMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
             "short": "Move (register)",
         },
         {
             "instr": "VMOV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
             "short": "Insert floating-point immediate in single-precision or double-precision register, or copy one FP register into another FP register of the same width",
         },
     ],
     "VMOVL": [
         {
             "instr": "VMOVL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964290.htm",
             "short": "Move Long",
         }
     ],
     "VMOV{U}N": [
         {
             "instr": "VMOV{U}N",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977128.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977128.htm",
             "short": "Move Narrow (register)",
         }
     ],
     "VMRS": [
         {
             "instr": "VMRS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
             "short": "Transfer contents from a floating-point system register to an ARM register",
         }
     ],
     "VMSR": [
         {
             "instr": "VMSR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
             "short": "Transfer contents from an ARM register to a floating-point system register",
         }
     ],
     "VMUL": [
         {
             "instr": "VMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Multiply (vector)",
         },
         {
             "instr": "VMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Multiply (by scalar)",
         },
         {
             "instr": "VMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Multiply",
         },
     ],
     "VMVN": [
         {
             "instr": "VMVN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964640.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289964640.htm",
             "short": "Move Negative (immediate)",
         }
     ],
     "VNEG": [
         {
             "instr": "VNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289968850.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289968850.htm",
             "short": "Negate",
         },
         {
             "instr": "VNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289968850.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289968850.htm",
             "short": "Negate",
         },
     ],
     "VNMLA": [
         {
             "instr": "VNMLA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289958611.htm",
             "short": "Negated multiply accumulate",
         }
     ],
     "VNMLS": [
         {
             "instr": "VNMLS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289960701.htm",
             "short": "Negated multiply subtract",
         }
     ],
     "VNMUL": [
         {
             "instr": "VNMUL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Negated multiply",
         }
     ],
     "VORN": [
         {
             "instr": "VORN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
             "short": "Bitwise OR NOT",
         },
         {
             "instr": "VORN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289952722.htm",
             "short": "Bitwise OR NOT (pseudo-instruction)",
         },
     ],
     "VORR": [
         {
             "instr": "VORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
             "short": "Bitwise OR (register)",
         },
         {
             "instr": "VORR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425898123112.htm",
             "short": "Bitwise OR (immediate)",
         },
     ],
     "VPADAL": [
         {
             "instr": "VPADAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289972209.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289972209.htm",
             "short": "Pairwise Add and Accumulate",
         }
     ],
     "VPADD": [
         {
             "instr": "VPADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289973079.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289973079.htm",
             "short": "Pairwise Add",
         }
     ],
     "VPMAX": [
         {
             "instr": "VPMAX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974299.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974299.htm",
             "short": "Pairwise Maximum",
         }
     ],
     "VPMIN": [
         {
             "instr": "VPMIN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974299.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974299.htm",
             "short": "Pairwise Minimum",
         }
     ],
     "VPOP": [
         {
             "instr": "VPOP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974629.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974629.htm",
             "short": "Extension register load multiple",
         }
     ],
     "VPUSH": [
         {
             "instr": "VPUSH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974949.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289974949.htm",
             "short": "Extension register store multiple",
         }
     ],
     "VQABS": [
         {
             "instr": "VQABS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289975389.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289975389.htm",
             "short": "Absolute value, saturate",
         }
     ],
     "VQADD": [
         {
             "instr": "VQADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289975719.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289975719.htm",
             "short": "Add, saturate",
         }
     ],
     "VQDMLAL": [
         {
             "instr": "VQDMLAL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289959991.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289959991.htm",
             "short": "Saturating Doubling Multiply Accumulate",
         }
     ],
     "VQDMLSL": [
         {
             "instr": "VQDMLSL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289961391.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289961391.htm",
             "short": "Saturating Doubling Multiply Subtract",
         }
     ],
     "VQDMULH": [
         {
             "instr": "VQDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Saturating Doubling Multiply returning High half",
         }
     ],
     "VQDMULL": [
         {
             "instr": "VQDMULL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289967170.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289967170.htm",
             "short": "Saturating Doubling Multiply",
         }
     ],
     "VQMOV{U}N": [
         {
             "instr": "VQMOV{U}N",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977128.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977128.htm",
             "short": "Saturating Move (register)",
         }
     ],
     "VQNEG": [
         {
             "instr": "VQNEG",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977458.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289977458.htm",
             "short": "Negate, saturate",
         }
     ],
     "VQRDMULH": [
         {
             "instr": "VQRDMULH",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289966080.htm",
             "short": "Saturating Doubling Multiply returning High half",
         }
     ],
     "VQRSHL": [
         {
             "instr": "VQRSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983597.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983597.htm",
             "short": "Shift Left, Round, saturate (by signed variable)",
         }
     ],
     "VQRSHR{U}N": [
         {
             "instr": "VQRSHR{U}N",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
             "short": "Shift Right, Round, saturate (by immediate)",
         }
     ],
     "VQSHL": [
         {
             "instr": "VQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
             "short": "Shift Left, saturate (by immediate)",
         },
         {
             "instr": "VQSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
             "short": "Shift Left, saturate (by signed variable)",
         },
     ],
     "VQSHR{U}N": [
         {
             "instr": "VQSHR{U}N",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289979988.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289979988.htm",
             "short": "Shift Right, saturate (by immediate)",
         }
     ],
     "VQSUB": [
         {
             "instr": "VQSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289979988.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289979988.htm",
             "short": "Subtract, saturate",
         }
     ],
     "VRADDHN": [
         {
             "instr": "VRADDHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289980388.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289980388.htm",
             "short": "Add, select High half, Round",
         }
     ],
     "VRECPE": [
         {
             "instr": "VRECPE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289980708.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289980708.htm",
             "short": "Reciprocal Estimate",
         }
     ],
     "VRECPS": [
         {
             "instr": "VRECPS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289981068.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289981068.htm",
             "short": "Reciprocal Step",
         }
     ],
     "VREV": [
         {
             "instr": "VREV",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901506568.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425901506568.htm",
             "short": "Reverse elements",
         }
     ],
     "VRHADD": [
         {
             "instr": "VRHADD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289981768.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289981768.htm",
             "short": "Halving Add, Round",
         }
     ],
     "VRINT": [
         {
             "instr": "VRINT",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211604.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211604.htm",
             "short": "Round to integer",
         }
     ],
     "VRSHR": [
         {
             "instr": "VRSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
             "short": "Shift Right and Round (by immediate)",
         }
     ],
     "VRSHRN": [
         {
             "instr": "VRSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
             "short": "Shift Right, Round, Narrow (by immediate)",
         }
     ],
     "VRSQRTE": [
         {
             "instr": "VRSQRTE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983217.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983217.htm",
             "short": "Reciprocal Square Root Estimate",
         }
     ],
     "VRSQRTS": [
         {
             "instr": "VRSQRTS",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983597.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289983597.htm",
             "short": "Reciprocal Square Root Step",
         }
     ],
     "VRSRA": [
         {
             "instr": "VRSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424433211144.htm",
             "short": "Shift Right, Round, and Accumulate (by immediate)",
         }
     ],
     "VRSUBHN": [
         {
             "instr": "VRSUBHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289984317.htm",
             "short": "Subtract, select High half, Round",
         }
     ],
     "VSHL": [
         {
             "instr": "VSHL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289944294.htm",
             "short": "Shift Left (by immediate)",
         }
     ],
     "VSHR": [
         {
             "instr": "VSHR",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
             "short": "Shift Right (by immediate)",
         }
     ],
     "VSHRN": [
         {
             "instr": "VSHRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992406.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992406.htm",
             "short": "Shift Right, Narrow (by immediate)",
         }
     ],
     "VSLI": [
         {
             "instr": "VSLI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289987667.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289987667.htm",
             "short": "Shift Left and Insert",
         }
     ],
     "VSRA": [
         {
             "instr": "VSRA",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1424868721235.htm",
             "short": "Shift Right, Accumulate (by immediate)",
         }
     ],
     "VSRI": [
         {
             "instr": "VSRI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289989376.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289989376.htm",
             "short": "Shift Right and Insert",
         }
     ],
     "VST": [
         {
             "instr": "VST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289989776.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289989776.htm",
             "short": "Vector Store",
         }
     ],
     "VSUB": [
         {
             "instr": "VSUB",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992056.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992056.htm",
             "short": "Subtract",
         }
     ],
     "VSUBHN": [
         {
             "instr": "VSUBHN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992406.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289992406.htm",
             "short": "Subtract, select High half",
         }
     ],
     "VSWP": [
         {
             "instr": "VSWP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993116.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993116.htm",
             "short": "Swap vectors",
         }
     ],
     "VTBL": [
         {
             "instr": "VTBL",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993506.htm",
             "short": "Vector table look-up",
         }
     ],
     "VTBX": [
         {
             "instr": "VTBX",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993506.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289993506.htm",
             "short": "Vector table look-up",
         }
     ],
     "VTRN": [
         {
             "instr": "VTRN",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289994926.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289994926.htm",
             "short": "Vector transpose",
         }
     ],
     "VTST": [
         {
             "instr": "VTST",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289995306.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289995306.htm",
             "short": "Test bits",
         }
     ],
     "VUZP": [
         {
             "instr": "VUZP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289995635.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289995635.htm",
             "short": "Vector de-interleave",
         }
     ],
     "VZIP": [
         {
             "instr": "VZIP",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289996005.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_dom1361289996005.htm",
             "short": "Vector interleave",
         }
     ],
     "WFE": [
         {
             "instr": "WFE",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917119639.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917119639.htm",
             "short": "Wait For Event",
         }
     ],
     "WFI": [
         {
             "instr": "WFI",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917144829.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917144829.htm",
             "short": "Wait For Interrupt",
         }
     ],
     "YIELD": [
         {
             "instr": "YIELD",
-            "link": "http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917160673.htm",
+            "link": "https://web.archive.org/web/20180914001719/http://www.keil.com/support/man/docs/armclang_asm/armclang_asm_pge1425917160673.htm",
             "short": "Yield",
         }
     ],


### PR DESCRIPTION
This fixes the broken links for the UAL and AArch64 documentation by prefixing the URLs with `archive.org` (which may not be the best solution but it works).